### PR TITLE
[added] Better Modal state management

### DIFF
--- a/examples/Modal.js
+++ b/examples/Modal.js
@@ -2,28 +2,37 @@ import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import Modal from 'react-overlays/Modal';
 
-const ModalStyle = {
+let rand = ()=> (Math.floor(Math.random() * 20) - 10);
+
+const modalStyle = {
   position: 'fixed',
   zIndex: 1040,
   top: 0, bottom: 0, left: 0, right: 0
 };
 
-const BackdropStyle = {
-  ...ModalStyle,
+const backdropStyle = {
+  ...modalStyle,
   zIndex: 'auto',
   backgroundColor: '#000',
   opacity: 0.5
 };
 
-const DialogStyle = {
-  position: 'absolute',
-  width: 400,
-  top: '50%', left: '50%',
-  transform: 'translate(-50%, -50%)',
-  border: '1px solid #e5e5e5',
-  backgroundColor: 'white',
-  boxShadow: '0 5px 15px rgba(0,0,0,.5)',
-  padding: 20
+const dialogStyle = function() {
+  // we use some psuedo random coords so modals
+  // don't sit right on top of each other.
+  let top = 50 + rand();
+  let left = 50 + rand();
+
+  return {
+    position: 'absolute',
+    width: 400,
+    top: top + '%', left: left + '%',
+    transform: `translate(-${top}%, -${left}%)`,
+    border: '1px solid #e5e5e5',
+    backgroundColor: 'white',
+    boxShadow: '0 5px 15px rgba(0,0,0,.5)',
+    padding: 20
+  };
 };
 
 
@@ -31,14 +40,6 @@ const ModalExample = React.createClass({
 
   getInitialState(){
     return { showModal: false };
-  },
-
-  close(){
-    this.setState({ showModal: false });
-  },
-
-  open(){
-    this.setState({ showModal: true });
   },
 
   render() {
@@ -51,18 +52,27 @@ const ModalExample = React.createClass({
         <p>Click to get the full Modal experience!</p>
 
         <Modal
-          style={ModalStyle}
-          backdropStyle={BackdropStyle}
+          style={modalStyle}
+          backdropStyle={backdropStyle}
           show={this.state.showModal}
           onHide={this.close}
         >
-          <div style={DialogStyle}>
+          <div style={dialogStyle()}>
             <h4>Text in a modal</h4>
             <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
+            <ModalExample/>
           </div>
         </Modal>
       </div>
     );
+  },
+
+  close(){
+    this.setState({ showModal: false });
+  },
+
+  open(){
+    this.setState({ showModal: true });
   }
 });
 

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -1,0 +1,127 @@
+import css from 'dom-helpers/style';
+import classes from 'dom-helpers/class';
+import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
+import isWindow from 'dom-helpers/query/isWindow';
+
+function containerClientHeight(container) {
+  let win = isWindow(container);
+  return win
+      ? win.documentElement.clientHeight
+      : container.clientHeight;
+}
+
+let findContainer = (data, modal)=> {
+  let idx = -1;
+  data.some((d, i)=> {
+    if (d.modals.indexOf(modal) !== -1){
+      idx = i;
+      return true;
+    }
+  });
+  return idx;
+};
+
+
+/**
+ * Proper state managment for containers and the modals in those containers.
+ */
+class ModalManager {
+
+  constructor(){
+    this.modals = [];
+    this.containers = [];
+    this.data = [];
+  }
+
+  add(modal, container, className){
+    let modalIdx = this.modals.indexOf(modal);
+    let containerIdx = this.containers.indexOf(container);
+
+    if (modalIdx !== -1) {
+      return modalIdx;
+    }
+
+    modalIdx = this.modals.length;
+    this.modals.push(modal);
+
+    if ( containerIdx !== -1) {
+      this.data[containerIdx].modals.push(modal);
+      return modalIdx;
+    }
+
+    let data = {
+      modals: [ modal ],
+      //right now only the first modal of a container will have its classes applied
+      classes: className ? className.split(/\s+/) : [],
+      //we are only interested in the actual `style` here becasue we will override it
+      style: {
+        overflow: container.style.overflow,
+        paddingRight: container.style.paddingRight
+      }
+    };
+
+    let style = {
+      overflow: 'hidden'
+    };
+
+    data.overflowing = container.scrollHeight > containerClientHeight(container);
+
+    if (data.overflowing) {
+      //use computed style, if necessary, here to get the real padding
+      style.paddingRight =
+        parseInt(css(container, 'paddingRight') || 0, 10) + getScrollbarSize() + 'px';
+    }
+
+    css(container, style);
+
+    data.classes.forEach(
+      classes.addClass.bind(null, container));
+
+    this.containers.push(container);
+    this.data.push(data);
+
+    return modalIdx;
+  }
+
+  remove(modal){
+    let modalIdx = this.modals.indexOf(modal);
+
+    if (modalIdx === -1) {
+      return;
+    }
+
+    let containerIdx = findContainer(this.data, modal);
+    let data = this.data[containerIdx];
+    let container = this.containers[containerIdx];
+
+    data.modals.splice(
+      data.modals.indexOf(modal), 1);
+
+    this.modals.splice(modalIdx, 1);
+
+    //if that was the last modal in a container, clean it up.
+    if (data.modals.length === 0){
+      Object.keys(data.style).forEach(
+        key => container.style[key] = data.style[key]);
+
+      data.classes.forEach(
+        classes.removeClass.bind(null, container));
+
+      this.containers.splice(containerIdx, 1);
+      this.data.splice(containerIdx, 1);
+    }
+  }
+
+  isContainerOverflowing(container){
+    let idx = this.containers.indexOf(container);
+
+    return idx === -1 || this.data[idx].overflowing;
+  }
+
+  isTopModal(modal){
+    return !!this.modals.length
+        && this.modals[this.modals.length - 1] === modal;
+  }
+}
+
+export default ModalManager;

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -21,9 +21,15 @@ let findContainer = (data, modal)=> {
   return idx;
 };
 
+function remove(arr, item){
+  let i = arr.indexOf(item);
+  if (i !== -1 ){ arr.splice(i, 0); }
+}
 
 /**
  * Proper state managment for containers and the modals in those containers.
+ *
+ * @internal Used by the Modal to ensure proper styling of containers.
  */
 class ModalManager {
 
@@ -31,6 +37,8 @@ class ModalManager {
     this.modals = [];
     this.containers = [];
     this.data = [];
+
+    this._listeners = [];
   }
 
   add(modal, container, className){
@@ -60,6 +68,7 @@ class ModalManager {
       }
     };
 
+
     let style = {
       overflow: 'hidden'
     };
@@ -67,7 +76,8 @@ class ModalManager {
     data.overflowing = container.scrollHeight > containerClientHeight(container);
 
     if (data.overflowing) {
-      //use computed style, if necessary, here to get the real padding
+      // use computed style, here to get the real padding
+      // to add our scrollbar width
       style.paddingRight =
         parseInt(css(container, 'paddingRight') || 0, 10) + getScrollbarSize() + 'px';
     }
@@ -112,13 +122,16 @@ class ModalManager {
     }
   }
 
-  isContainerOverflowing(container){
-    let idx = this.containers.indexOf(container);
-
-    return idx === -1 || this.data[idx].overflowing;
+  listen(handler){
+    this._listeners.push(handler);
+    return ()=> remove(this.listeners, handler);
   }
 
-  isTopModal(modal){
+  _emit(args){
+    this._listeners.forEach(l => l.apply(this, args));
+  }
+
+  isTopModal(modal) {
     return !!this.modals.length
         && this.modals[this.modals.length - 1] === modal;
   }

--- a/src/utils/addFocusListener.js
+++ b/src/utils/addFocusListener.js
@@ -1,0 +1,20 @@
+/**
+ * Firefox doesn't have a focusin event so using capture is easiest way to get bubbling
+ * IE8 can't do addEventListener, but does have onfocusin, so we use that in ie8
+ *
+ * We only allow one Listener at a time to avoid stack overflows
+ */
+export default function addFocusListener(handler) {
+  let useFocusin = !document.addEventListener;
+  let remove;
+
+  if (useFocusin) {
+    document.attachEvent('onfocusin', handler);
+    remove = () => document.detachEvent('onfocusin', handler);
+  } else {
+    document.addEventListener('focus', handler, true);
+    remove = () => document.removeEventListener('focus', handler, true);
+  }
+
+  return { remove };
+}

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -1,0 +1,188 @@
+import Modal from '../src/Modal';
+import ModalManager from '../src/ModalManager';
+import { injectCss } from './helpers';
+import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
+import css from 'dom-helpers/style';
+
+describe('ModalManager', ()=> {
+  let container
+    , manager;
+
+  beforeEach(()=>{
+    manager = new ModalManager();
+    container = document.createElement('div');
+    container.setAttribute('id', 'container');
+    document.body.appendChild(container);
+  });
+
+  afterEach(()=>{
+    document.body.removeChild(container);
+    container = null;
+    manager = null;
+  });
+
+  it('should add Modal', ()=>{
+    let modal = new Modal({});
+
+    manager.add(modal, container);
+
+    expect(manager.modals.length).to.equal(1);
+    expect(manager.modals[0]).to.equal(modal);
+
+    expect(manager.containers[0]).to.equal(container);
+    expect(manager.data[0]).to.eql({
+      modals: [modal],
+      classes: [],
+      overflowing: false,
+      style: {
+        overflow: '',
+        paddingRight: ''
+      }
+    });
+  });
+
+  it('should not add a modal twice', ()=>{
+    let modal = new Modal({});
+    manager.add(modal, container);
+    manager.add(modal, container);
+
+    expect(manager.modals.length).to.equal(1);
+    expect(manager.containers.length).to.equal(1);
+    expect(manager.data[0].modals.length).to.equal(1);
+  });
+
+  it('should not add a container twice', ()=>{
+    let modalA = new Modal({});
+    let modalB = new Modal({});
+
+    manager.add(modalA, container);
+    manager.add(modalB, container);
+
+    expect(manager.modals.length).to.equal(2);
+    expect(manager.containers.length).to.equal(1);
+    expect(manager.data[0].modals.length).to.equal(2);
+  });
+
+  it('should remove modal', ()=>{
+    let modalA = new Modal({});
+    let modalB = new Modal({});
+
+    manager.add(modalA, container);
+    manager.add(modalB, container);
+
+    manager.remove(modalA);
+
+    expect(manager.modals.length).to.equal(1);
+    expect(manager.containers.length).to.equal(1);
+    expect(manager.data[0].modals.length).to.equal(1);
+  });
+
+  it('should remove container when there are no more modals associated with it', ()=>{
+    let modalA = new Modal({});
+    let modalB = new Modal({});
+
+    manager.add(modalA, container);
+    manager.add(modalB, container);
+
+    expect(manager.data[0].modals.length).to.equal(2);
+
+    manager.remove(modalA);
+    manager.remove(modalB);
+
+    expect(manager.modals.length).to.equal(0);
+    expect(manager.containers.length).to.equal(0);
+    expect(manager.data.length).to.equal(0);
+  });
+
+  describe('container styles', ()=>{
+
+    beforeEach(()=> {
+      container.appendChild(
+        document.createElement('div'));
+      injectCss(`
+        #container {
+          padding-right: 20px;
+          overflow: scroll;
+          height: 300px;
+        }
+
+        #container > div {
+          height: 1000px;
+        }
+      `);
+    });
+
+    afterEach(()=> injectCss.reset());
+
+    it('should set container overflow to hidden ', ()=>{
+      let modal = new Modal({});
+
+      expect(container.style.overflow).to.equal('');
+
+      manager.add(modal, container);
+
+      expect(container.style.overflow).to.equal('hidden');
+    });
+
+    it('should set add to existing container padding', ()=>{
+      let modal = new Modal({});
+      manager.add(modal, container);
+      expect(container.style.paddingRight).to.equal((getScrollbarSize() + 20) + 'px');
+    });
+
+    it('should add container classes ', ()=>{
+      let modal = new Modal({});
+
+      expect(container.className).to.equal('');
+
+      manager.add(modal, container, 'test test-other');
+
+       expect(container.className).to.equal('test test-other');
+    });
+
+    it('should restore container overflow style', ()=> {
+      let modal = new Modal({});
+
+      container.style.overflow = 'scroll';
+
+      expect(container.style.overflow).to.equal('scroll');
+
+      manager.add(modal, container);
+      manager.remove(modal);
+
+      expect(container.style.overflow).to.equal('scroll');
+    });
+
+    it('should reset overflow style to the computed one', ()=> {
+      let modal = new Modal({});
+
+      expect(css(container, 'overflow')).to.equal('scroll');
+
+      manager.add(modal, container);
+      manager.remove(modal);
+
+      expect(container.style.overflow).to.equal('');
+      expect(css(container, 'overflow')).to.equal('scroll');
+    });
+
+    it('should only remove styles when there are no associated modals', ()=>{
+      let modalA = new Modal({});
+      let modalB = new Modal({});
+
+      expect(container.style.overflow).to.equal('');
+
+      manager.add(modalA, container);
+      manager.add(modalB, container);
+
+      manager.remove(modalB);
+
+      expect(container.style.overflow).to.equal('hidden');
+
+      manager.remove(modalA);
+
+      expect(container.style.overflow).to.equal('');
+      expect(container.style.paddingRight).to.equal('');
+    });
+  });
+
+});

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -5,8 +5,7 @@ import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import css from 'dom-helpers/style';
 
 describe('ModalManager', ()=> {
-  let container
-    , manager;
+  let container, manager;
 
   beforeEach(()=>{
     manager = new ModalManager();

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -11,7 +11,6 @@ let $ = componentOrNode => jquery(React.findDOMNode(componentOrNode));
 describe('Modal', function () {
   let mountPoint;
 
-
   beforeEach(()=>{
     mountPoint = document.createElement('div');
     document.body.appendChild(mountPoint);
@@ -173,6 +172,51 @@ describe('Modal', function () {
       backdrop.style.borderWidth).to.equal('3px');
   });
 
+  it('Should throw with multiple children', function () {
+    expect(function(){
+      render(
+        <Modal show>
+          <strong>Message</strong>
+          <strong>Message</strong>
+        </Modal>
+      , mountPoint);
+    }).to.throw(
+      'Invariant Violation: onlyChild must be passed a children with exactly one child.');
+  });
+
+  it('Should add role to child', function () {
+    let instance = render(
+      <Modal show>
+        <strong>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    expect(
+      instance.getDialogElement().getAttribute('role')).to.equal('document');
+  });
+
+  it('Should not add role when SET', function () {
+    let instance = render(
+      <Modal show>
+        <strong role='group'>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    expect(
+      instance.getDialogElement().getAttribute('role')).to.equal('group');
+  });
+
+  it('Should not add role when explicitly `null`', function () {
+    let instance = render(
+      <Modal show>
+        <strong role={null}>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    expect(
+      instance.getDialogElement().getAttribute('role')).to.equal(null);
+  });
+
   it('Should unbind listeners when unmounted', function() {
     render(
         <div>
@@ -198,7 +242,6 @@ describe('Modal', function () {
         transition={Transition}
         dialogTransitionTimeout={0}
         backdropTransitionTimeout={0}
-        onHide={()=>{}}
         onExit={increment}
         onExiting={increment}
         onExited={()=> {
@@ -218,14 +261,13 @@ describe('Modal', function () {
       , mountPoint);
   });
 
-
-
   describe('Focused state', function () {
     let focusableContainer = null;
 
     beforeEach(()=>{
       focusableContainer = document.createElement('div');
       focusableContainer.tabIndex = 0;
+      focusableContainer.className = 'focus-container';
       document.body.appendChild(focusableContainer);
       focusableContainer.focus();
     });
@@ -240,7 +282,7 @@ describe('Modal', function () {
       document.activeElement.should.equal(focusableContainer);
 
       let instance = render(
-        <Modal show onHide={()=>{}} className='modal'>
+        <Modal show className='modal'>
           <strong>Message</strong>
         </Modal>
         , focusableContainer);
@@ -255,7 +297,7 @@ describe('Modal', function () {
 
     it('Should not focus on the Modal when autoFocus is false', function () {
       render(
-        <Modal show autoFocus={false} onHide={()=>{}}>
+        <Modal show autoFocus={false}>
           <strong>Message</strong>
         </Modal>
         , focusableContainer);
@@ -268,7 +310,7 @@ describe('Modal', function () {
       document.activeElement.should.equal(focusableContainer);
 
       render(
-        <Modal show onHide={()=>{}}>
+        <Modal show>
           <input autoFocus />
         </Modal>
         , focusableContainer);
@@ -276,6 +318,20 @@ describe('Modal', function () {
       let input = document.getElementsByTagName('input')[0];
 
       document.activeElement.should.equal(input);
+    });
+
+    it('Should return focus to the modal', function () {
+
+      document.activeElement.should.equal(focusableContainer);
+
+      render(
+        <Modal show className='modal'>
+          <input autoFocus/>
+        </Modal>
+        , focusableContainer);
+
+      focusableContainer.focus();
+      document.activeElement.className.should.contain('modal');
     });
   });
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -28,3 +28,31 @@ export function render(element, mountPoint){
 
   return instance;
 }
+
+
+let style;
+let seen = [];
+
+export function injectCss(rules){
+  if ( seen.indexOf(rules) !== -1 ){
+    return;
+  }
+
+  style = style || (function() {
+    let _style = document.createElement('style');
+    _style.appendChild(document.createTextNode(''));
+    document.head.appendChild(_style);
+    return _style;
+  })();
+
+  seen.push(rules);
+  style.innerHTML += '\n' + rules;
+}
+
+injectCss.reset = function(){
+  if ( style ) {
+    document.head.removeChild(style);
+  }
+  style = null;
+  seen = [];
+};

--- a/webpack/test-coverage.config.js
+++ b/webpack/test-coverage.config.js
@@ -1,5 +1,4 @@
 import path from 'path';
-import { jsLoader } from './base.config';
 import testConfig from './test.config';
 
 const paths = {
@@ -15,7 +14,7 @@ export default {
       {
         test: /\.js/,
         include: [paths.SRC, paths.TEST],
-        loader: jsLoader,
+        loader: 'babel-loader',
         exclude: /node_modules/
       }
     ],

--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -11,5 +11,5 @@ export default {
     ]
   },
 
-  devtool: 'eval'
+  devtool: 'inline-source-map'
 };


### PR DESCRIPTION
Abstract out all the container styling and modal jumbling.

This lets us properly support having more then one modal open at at time, by removing all those assumptions.

We still need to think of a proper api to expose to Modal consumers, since they will need to know certain info like the modal's position in the overall stack for styling backdrops correctly. There is a longer term question of allowing a write-access api to the manager if folks want to implement more full blown windows, where they'd need to reorder the stack(s).

__bonus__ we could make this all pluggable so if folks really want to get into it they can just provide their own manager