### PR TITLE
Set default top and left position

### DIFF
--- a/src/Position.js
+++ b/src/Position.js
@@ -20,8 +20,8 @@ class Position extends React.Component {
     super(props, context);
 
     this.state = {
-      positionLeft: null,
-      positionTop: null,
+      positionLeft: 0,
+      positionTop: 0,
       arrowOffsetLeft: null,
       arrowOffsetTop: null
     };
@@ -99,8 +99,8 @@ class Position extends React.Component {
 
     if (!target) {
       this.setState({
-        positionLeft: null,
-        positionTop: null,
+        positionLeft: 0,
+        positionTop: 0,
         arrowOffsetLeft: null,
         arrowOffsetTop: null
       });


### PR DESCRIPTION
This should help prevent overflow on some elements while calculating the target's position.
I found this to be useful when using Overlay if the new element forces the browser to display a scrollbar.
Without setting a position static elements shouldn't be affected, but this might cause problems for elements with a relative position.