### PR TITLE
Fix transition in behaviour for unmountOnExit

### DIFF
--- a/src/Transition.js
+++ b/src/Transition.js
@@ -72,7 +72,7 @@ class Transition extends React.Component {
       // EXITED is always a transitional state to either ENTERING or UNMOUNTED
       // when using unmountOnExit.
       if (this.props.in) {
-        this.performEnter(this.props);
+        setTimeout(() => this.performEnter(this.props), 0);
       } else {
         this.setState({status: UNMOUNTED});
       }


### PR DESCRIPTION
It seems that if you're using the `unmountOnExit` option, then the Transition component both mounts your child component _and_ applies the `enteringClassName` in the same Javascript tick, this causes the browser to not trigger the animation (and instead the `enteringClassName` attributes are immediately applied).

By forcing a wait until the next Javascript tick in this case animation appears to reliable happen.