### PR TITLE
[changed] Friendlier default for AutoAffix

### DIFF
--- a/src/AutoAffix.js
+++ b/src/AutoAffix.js
@@ -152,6 +152,7 @@ AutoAffix.propTypes = {
 // This intentionally doesn't inherit default props from `<Affix>`, so that the
 // auto-calculated offsets can apply.
 AutoAffix.defaultProps = {
+  viewportOffsetTop: 0,
   autoWidth: true
 };
 


### PR DESCRIPTION
This is really just for consistency with what I'm adding in React-Bootstrap. In practice when using `<AutoAffix>`, this just seems like a much saner default.