### PR TITLE
Add dynamicPosition prop to Position component

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -30,6 +30,7 @@ class Overlay extends React.Component {
       , containerPadding
       , target
       , placement
+      , shouldUpdatePosition
       , rootClose
       , children
       , transition: Transition
@@ -48,7 +49,7 @@ class Overlay extends React.Component {
     // Position is be inner-most because it adds inline styles into the child,
     // which the other wrappers don't forward correctly.
     child = (
-      <Position {...{container, containerPadding, target, placement}}>
+      <Position {...{container, containerPadding, target, placement, shouldUpdatePosition}}>
         {child}
       </Position>
     );

--- a/src/Position.js
+++ b/src/Position.js
@@ -92,7 +92,7 @@ class Position extends React.Component {
   updatePosition(placementChanged) {
     const target = this.getTargetSafe();
 
-    if (target === this._lastTarget && !placementChanged) {
+    if (!this.props.shouldUpdatePosition && target === this._lastTarget && !placementChanged) {
       return;
     }
 
@@ -138,14 +138,19 @@ Position.propTypes = {
   /**
    * How to position the component relative to the target
    */
-  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
+  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  /**
+   * Whether the position should be changed on each update
+   */
+  shouldUpdatePosition: React.PropTypes.bool
 };
 
 Position.displayName = 'Position';
 
 Position.defaultProps = {
   containerPadding: 0,
-  placement: 'right'
+  placement: 'right',
+  shouldUpdatePosition: false
 };
 
 export default Position;

--- a/test/PositionSpec.js
+++ b/test/PositionSpec.js
@@ -92,6 +92,51 @@ describe('Position', function () {
       expect(overlayPositionUtils.calcOverlayPosition)
         .to.have.been.calledTwice;
     });
+
+    it('Should recalculate position if shouldUpdatePosition prop is true', function () {
+      class Target extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.state = {
+            target: 'bar',
+            fakeProp: 0
+          };
+        }
+
+        render() {
+          return (
+            <div>
+              <div ref="bar" />
+
+              <Position
+                target={() => this.refs[this.state.target]}
+                shouldUpdatePosition
+                fakeProp={this.state.fakeProp}
+              >
+                <div />
+              </Position>
+            </div>
+          );
+        }
+      }
+
+      const instance = ReactTestUtils.renderIntoDocument(<Target />);
+
+      // Position calculates initial position.
+      expect(Position.prototype.componentWillReceiveProps)
+        .to.have.not.been.called;
+      expect(overlayPositionUtils.calcOverlayPosition)
+        .to.have.been.calledOnce;
+
+      instance.setState({fakeProp: 1});
+
+      // Position receives new props and position should be recalculated
+      expect(Position.prototype.componentWillReceiveProps)
+        .to.have.been.calledOnce;
+      expect(overlayPositionUtils.calcOverlayPosition)
+        .to.have.been.calledTwice;
+    });
   });
 
   describe('position calculation', function () {


### PR DESCRIPTION
This adds the `dynamicPosition` prop to the `Position` component in order to allow for the popover to be repositioned when content changes. It is turned off by default so it should not affect any existing code.

This goes with this issue on react-bootstrap: https://github.com/react-bootstrap/react-bootstrap/issues/1438