### PR TITLE
Can use (but probably shouldn't) multiple modals at once

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -161,7 +161,11 @@ const Modal = React.createClass({
     let show = !!props.show;
     let dialog = React.Children.only(this.props.children);
 
-    let setMountNode = ref => this.mountNode = (!ref || ref.getMountNode());
+    let setMountNode = ref => {
+      if (ref !== null && typeof ref === 'object') {
+        this.mountNode = ref.getMountNode();
+      }
+    }
 
     const mountModal = show || (Transition && !this.state.exited);
 


### PR DESCRIPTION
Fixes #41. Please pull n publish this as atm react-bootstrap's modals, when used multiple at a time, are broken.