### PR TITLE
createChainedFunction supports for falsy

### DIFF
--- a/src/utils/createChainedFunction.js
+++ b/src/utils/createChainedFunction.js
@@ -9,10 +9,10 @@
  */
 function createChainedFunction(...funcs) {
   return funcs
-    .filter(f => f != null)
+    .filter(f => f)
     .reduce((acc, f) => {
       if (typeof f !== 'function') {
-        throw new Error('Invalid Argument Type, must only provide functions, undefined, or null.');
+        throw new Error('Invalid Argument Type, must only provide functions or falsy.');
       }
 
       if (acc === null) {


### PR DESCRIPTION
The original `createChainedFunction` does not handle `undefined` properly. It throws when receiving `undefined`. This pull request will make `createChainedFunction` handle all falsy values properly.