### PR TITLE
Portal container should be updated when container prop changes

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -32,6 +32,13 @@ let Portal = React.createClass({
     this._renderOverlay();
   },
 
+  componentWillReceiveProps(nextProps) {
+    if (this._overlayTarget && nextProps.container !== this.props.container) {
+      this.getContainerDOMNode().removeChild(this._overlayTarget)
+      this.getContainerDOMNode(nextProps).appendChild(this._overlayTarget)
+    }
+  },
+
   componentWillUnmount() {
     this._unrenderOverlay();
     this._unmountOverlayTarget();
@@ -104,8 +111,9 @@ let Portal = React.createClass({
     return null;
   },
 
-  getContainerDOMNode() {
-    return getContainer(this.props.container, ownerDocument(this).body);
+  getContainerDOMNode(props) {
+    props = props || this.props
+    return getContainer(props.container, ownerDocument(this).body);
   }
 });
 

--- a/test/PortalSpec.js
+++ b/test/PortalSpec.js
@@ -76,4 +76,34 @@ describe('Portal', function () {
 
     assert.equal(overlayInstance.refs.p.getOverlayDOMNode().nodeName, 'DIV');
   });
+
+  it('Should change container on prop change', function() {
+
+    let ContainerTest = React.createClass({
+      getInitialState() {
+        return {}
+      },
+      render() {
+        return (
+          <div>
+            <div ref='d' />
+            <Portal ref='p' {...this.props} container={this.state.container}>
+              {this.props.overlay}
+            </Portal>
+          </div>
+        );
+      }
+    });
+
+    let overlayInstance = ReactTestUtils.renderIntoDocument(
+      <ContainerTest overlay={<div id="test1" />} />
+    );
+
+    assert.equal(overlayInstance.refs.p.getContainerDOMNode().nodeName, 'BODY');
+    overlayInstance.setState({container: overlayInstance.refs.d})
+    assert.equal(overlayInstance.refs.p.getContainerDOMNode().nodeName, 'DIV');
+
+    React.unmountComponentAtNode(React.findDOMNode(overlayInstance).parentNode);
+  });
+
 });


### PR DESCRIPTION
Test included, fixes the error `The node to be removed is not a child of this node.` occurring on unmount when the `container` prop was being updated but the `_overlayTarget` was not being moved in the document.