### PR TITLE
Add /src to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "lib/index.js",
   "files": [
     "lib/",
+    "src/",
     "LICENSE",
     "README.md",
     "CHANGELOG.md"


### PR DESCRIPTION
Makes it possible for a user to write a postinstall script which builds the /src directory when installing from a github release.

I was looking to get the latest patches working with react-bootstrap, but noticed it hasn't been published yet and it's not possible to npm install the latest github version and manually but that too doesn't work because /src isn't included.