### PR TITLE
Fix unmounting portal when parent is unmounted

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -34,8 +34,9 @@ let Portal = React.createClass({
 
   componentWillReceiveProps(nextProps) {
     if (this._overlayTarget && nextProps.container !== this.props.container) {
-      this.getContainerDOMNode().removeChild(this._overlayTarget)
-      this.getContainerDOMNode(nextProps).appendChild(this._overlayTarget)
+      this._portalContainerNode.removeChild(this._overlayTarget);
+      this._portalContainerNode = getContainer(nextProps.container, ownerDocument(this).body);
+      this._portalContainerNode.appendChild(this._overlayTarget);
     }
   },
 
@@ -48,17 +49,17 @@ let Portal = React.createClass({
   _mountOverlayTarget() {
     if (!this._overlayTarget) {
       this._overlayTarget = document.createElement('div');
-      this.getContainerDOMNode()
-        .appendChild(this._overlayTarget);
+      this._portalContainerNode = getContainer(this.props.container, ownerDocument(this).body);
+      this._portalContainerNode.appendChild(this._overlayTarget);
     }
   },
 
   _unmountOverlayTarget() {
     if (this._overlayTarget) {
-      this.getContainerDOMNode()
-        .removeChild(this._overlayTarget);
+      this._portalContainerNode.removeChild(this._overlayTarget);
       this._overlayTarget = null;
     }
+    this._portalContainerNode = null;
   },
 
   _renderOverlay() {
@@ -109,12 +110,8 @@ let Portal = React.createClass({
     }
 
     return null;
-  },
-
-  getContainerDOMNode(props) {
-    props = props || this.props
-    return getContainer(props.container, ownerDocument(this).body);
   }
+
 });
 
 export default Portal;

--- a/test/PortalSpec.js
+++ b/test/PortalSpec.js
@@ -99,11 +99,46 @@ describe('Portal', function () {
       <ContainerTest overlay={<div id="test1" />} />
     );
 
-    assert.equal(overlayInstance.refs.p.getContainerDOMNode().nodeName, 'BODY');
+    assert.equal(overlayInstance.refs.p._portalContainerNode.nodeName, 'BODY');
     overlayInstance.setState({container: overlayInstance.refs.d})
-    assert.equal(overlayInstance.refs.p.getContainerDOMNode().nodeName, 'DIV');
+    assert.equal(overlayInstance.refs.p._portalContainerNode.nodeName, 'DIV');
 
-    React.unmountComponentAtNode(React.findDOMNode(overlayInstance).parentNode);
+    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(overlayInstance).parentNode);
+  });
+
+  it('Should unmount when parent unmounts', function() {
+
+    let Parent = React.createClass({
+      getInitialState() {
+        return {show: true}
+      },
+      render() {
+        return (
+          <div>
+            {this.state.show && <Child /> || null}
+          </div>
+        )
+      }
+    })
+
+    let Child = React.createClass({
+      render() {
+        return (
+          <div>
+            <div ref='d' />
+            <Portal ref='p' container={() => this.refs.d}>
+              <div id="test1" />
+            </Portal>
+          </div>
+        );
+      }
+    });
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Parent />
+    );
+
+    instance.setState({show: false});
   });
 
 });


### PR DESCRIPTION
When a portal is mounted and references a container which unmounts before the portal, an error occurs as the result of `getContainerDOMNode` will become "body" and removeChild fails. This removes `getContainerDOMNode` in favor of caching the container on the instance as `_portalContainerNode`.

Test included.