### PR TITLE
Make <RootCloseWrapper /> hide onmousedown instead of onclick

### DIFF
--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -147,5 +147,5 @@ RootCloseWrapper.propTypes = {
 };
 
 RootCloseWrapper.defaultProps = {
-  event: 'mousedown'
+  event: 'click'
 };

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -35,7 +35,7 @@ export default class RootCloseWrapper extends React.Component {
   constructor(props) {
     super(props);
 
-    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+    this.handleDocumentMousedown = this.handleDocumentMousedown.bind(this);
     this.handleDocumentKeyUp = this.handleDocumentKeyUp.bind(this);
 
     let { id, suppressRootClose } = getSuppressRootClose();
@@ -48,14 +48,14 @@ export default class RootCloseWrapper extends React.Component {
   bindRootCloseHandlers() {
     const doc = ownerDocument(this);
 
-    this._onDocumentClickListener =
-      addEventListener(doc, 'click', this.handleDocumentClick);
+    this._onDocumentMousedownListener =
+      addEventListener(doc, 'mousedown', this.handleDocumentMousedown);
 
     this._onDocumentKeyupListener =
       addEventListener(doc, 'keyup', this.handleDocumentKeyUp);
   }
 
-  handleDocumentClick(e) {
+  handleDocumentMousedown(e) {
     // This is now the native event.
     if (e[this._suppressRootId]) {
       return;
@@ -76,8 +76,8 @@ export default class RootCloseWrapper extends React.Component {
   }
 
   unbindRootCloseHandlers() {
-    if (this._onDocumentClickListener) {
-      this._onDocumentClickListener.remove();
+    if (this._onDocumentMousedownListener) {
+      this._onDocumentMousedownListener.remove();
     }
 
     if (this._onDocumentKeyupListener) {
@@ -95,14 +95,14 @@ export default class RootCloseWrapper extends React.Component {
 
     if (noWrap) {
       return React.cloneElement(child, {
-        onClick: createChainedFunction(this._suppressRootCloseHandler, child.props.onClick)
+        onMouseDown: createChainedFunction(this._suppressRootCloseHandler, child.props.onMouseDown)
       });
     }
 
     // Wrap the child in a new element, so the child won't have to handle
     // potentially combining multiple onClick listeners.
     return (
-      <div onClick={this._suppressRootCloseHandler}>
+      <div onMouseDown={this._suppressRootCloseHandler}>
         {child}
       </div>
     );

--- a/test/RootCloseSpec.js
+++ b/test/RootCloseSpec.js
@@ -17,76 +17,89 @@ describe('RootCloseWrapper', function () {
     document.body.removeChild(mountPoint);
   });
 
-  it('should close when clicked outside', () => {
-    let spy = sinon.spy();
-    render(
-      <RootCloseWrapper onRootClose={spy}>
-        <div id='my-div'>hello there</div>
-      </RootCloseWrapper>
-    , mountPoint);
-
-    simulant.fire(document.getElementById('my-div'), 'mousedown');
-
-    expect(spy).to.not.have.been.called;
-
-    simulant.fire(document.body, 'mousedown');
-
-    expect(spy).to.have.been.calledOnce;
+  describe('using default event', () => {
+    shouldCloseOn(undefined, 'mousedown');
   });
 
-  it('should not close when right-clicked outside', () => {
-    let spy = sinon.spy();
-    render(
-      <RootCloseWrapper onRootClose={spy}>
-        <div id='my-div'>hello there</div>
-      </RootCloseWrapper>
-    , mountPoint);
-
-    simulant.fire(document.getElementById('my-div'), 'mousedown', {button: 1});
-
-    expect(spy).to.not.have.been.called;
-
-    simulant.fire(document.body, 'mousedown', {button: 1});
-
-    expect(spy).to.not.have.been.called;
+  describe('using click event', () => {
+    shouldCloseOn('click', 'click');
   });
 
-  it('should not close when disabled', () => {
-    let spy = sinon.spy();
-    render(
-      <RootCloseWrapper onRootClose={spy} disabled>
-        <div id='my-div'>hello there</div>
-      </RootCloseWrapper>
-    , mountPoint);
-
-    simulant.fire(document.getElementById('my-div'), 'mousedown');
-
-    expect(spy).to.not.have.been.called;
-
-    simulant.fire(document.body, 'mousedown');
-
-    expect(spy).to.not.have.been.called;
+  describe('using mousedown event', () => {
+    shouldCloseOn('mousedown', 'mousedown');
   });
 
-  it('should close when inside another RootCloseWrapper', () => {
-    let outerSpy = sinon.spy();
-    let innerSpy = sinon.spy();
-
-    render(
-      <RootCloseWrapper onRootClose={outerSpy}>
-        <div>
+  function shouldCloseOn(eventProp, eventName) {
+    it('should close when clicked outside', () => {
+      let spy = sinon.spy();
+      render(
+        <RootCloseWrapper onRootClose={spy} event={eventProp}>
           <div id='my-div'>hello there</div>
-          <RootCloseWrapper onRootClose={innerSpy}>
-            <div id='my-other-div'>hello there</div>
-          </RootCloseWrapper>
-        </div>
-      </RootCloseWrapper>
-    , mountPoint);
+        </RootCloseWrapper>
+      , mountPoint);
 
-    simulant.fire(document.getElementById('my-div'), 'mousedown');
+      simulant.fire(document.getElementById('my-div'), eventName);
 
-    expect(outerSpy).to.have.not.been.called;
-    expect(innerSpy).to.have.been.calledOnce;
-  });
+      expect(spy).to.not.have.been.called;
 
+      simulant.fire(document.body, eventName);
+
+      expect(spy).to.have.been.calledOnce;
+    });
+
+    it('should not close when right-clicked outside', () => {
+      let spy = sinon.spy();
+      render(
+        <RootCloseWrapper onRootClose={spy} event={eventProp}>
+          <div id='my-div'>hello there</div>
+        </RootCloseWrapper>
+      , mountPoint);
+
+      simulant.fire(document.getElementById('my-div'), eventName, {button: 1});
+
+      expect(spy).to.not.have.been.called;
+
+      simulant.fire(document.body, eventName, {button: 1});
+
+      expect(spy).to.not.have.been.called;
+    });
+
+    it('should not close when disabled', () => {
+      let spy = sinon.spy();
+      render(
+        <RootCloseWrapper onRootClose={spy} event={eventProp} disabled>
+          <div id='my-div'>hello there</div>
+        </RootCloseWrapper>
+      , mountPoint);
+
+      simulant.fire(document.getElementById('my-div'), eventName);
+
+      expect(spy).to.not.have.been.called;
+
+      simulant.fire(document.body, eventName);
+
+      expect(spy).to.not.have.been.called;
+    });
+
+    it('should close when inside another RootCloseWrapper', () => {
+      let outerSpy = sinon.spy();
+      let innerSpy = sinon.spy();
+
+      render(
+        <RootCloseWrapper onRootClose={outerSpy} event={eventProp}>
+          <div>
+            <div id='my-div'>hello there</div>
+            <RootCloseWrapper onRootClose={innerSpy} event={eventProp}>
+              <div id='my-other-div'>hello there</div>
+            </RootCloseWrapper>
+          </div>
+        </RootCloseWrapper>
+      , mountPoint);
+
+      simulant.fire(document.getElementById('my-div'), eventName);
+
+      expect(outerSpy).to.have.not.been.called;
+      expect(innerSpy).to.have.been.calledOnce;
+    });
+  }
 });

--- a/test/RootCloseSpec.js
+++ b/test/RootCloseSpec.js
@@ -18,7 +18,7 @@ describe('RootCloseWrapper', function () {
   });
 
   describe('using default event', () => {
-    shouldCloseOn(undefined, 'mousedown');
+    shouldCloseOn(undefined, 'click');
   });
 
   describe('using click event', () => {

--- a/test/RootCloseSpec.js
+++ b/test/RootCloseSpec.js
@@ -25,11 +25,11 @@ describe('RootCloseWrapper', function () {
       </RootCloseWrapper>
     , mountPoint);
 
-    simulant.fire(document.getElementById('my-div'), 'click');
+    simulant.fire(document.getElementById('my-div'), 'mousedown');
 
     expect(spy).to.not.have.been.called;
 
-    simulant.fire(document.body, 'click');
+    simulant.fire(document.body, 'mousedown');
 
     expect(spy).to.have.been.calledOnce;
   });
@@ -42,11 +42,11 @@ describe('RootCloseWrapper', function () {
       </RootCloseWrapper>
     , mountPoint);
 
-    simulant.fire(document.getElementById('my-div'), 'click', {button: 1});
+    simulant.fire(document.getElementById('my-div'), 'mousedown', {button: 1});
 
     expect(spy).to.not.have.been.called;
 
-    simulant.fire(document.body, 'click', {button: 1});
+    simulant.fire(document.body, 'mousedown', {button: 1});
 
     expect(spy).to.not.have.been.called;
   });
@@ -59,11 +59,11 @@ describe('RootCloseWrapper', function () {
       </RootCloseWrapper>
     , mountPoint);
 
-    simulant.fire(document.getElementById('my-div'), 'click');
+    simulant.fire(document.getElementById('my-div'), 'mousedown');
 
     expect(spy).to.not.have.been.called;
 
-    simulant.fire(document.body, 'click');
+    simulant.fire(document.body, 'mousedown');
 
     expect(spy).to.not.have.been.called;
   });
@@ -83,7 +83,7 @@ describe('RootCloseWrapper', function () {
       </RootCloseWrapper>
     , mountPoint);
 
-    simulant.fire(document.getElementById('my-div'), 'click');
+    simulant.fire(document.getElementById('my-div'), 'mousedown');
 
     expect(outerSpy).to.have.not.been.called;
     expect(innerSpy).to.have.been.calledOnce;


### PR DESCRIPTION
As discussed in #92 

Unlike modal there's no background overlay, so click() is a bit late if the user is doing an interaction that starts onmousedown like dragging or clicking another button.

In order to run the examples from a fresh working tree I had to peg the component-playground version.

I've done some testing of this, I can't find any problems so far. The existing discussions about `mousedown` problems I've found have all been related to Modals and the background overlay.