### PR TITLE
Update demo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Utilities for creating robust overlay components
 
-demos and docs at: http://react-bootstrap.github.io/react-overlays/examples/
+demos and docs at: https://react-bootstrap.github.io/react-overlays/
 
 ## Install
 


### PR DESCRIPTION
The current link just 404s, this just updates it to use the same link that's provided in the description.