### PR TITLE
Enhance: Bind/Unbind root close handlers for RootCloseWrapper

### DIFF
--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -86,7 +86,22 @@ export default class RootCloseWrapper extends React.Component {
   }
 
   componentDidMount() {
-    this.bindRootCloseHandlers();
+    if (!this.props.disabled) {
+      this.bindRootCloseHandlers();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { disabled } = this.props;
+    const { disabled: prevDisabled } = prevProps;
+
+    if (disabled !== prevDisabled) {
+      if (disabled) {
+        this.unbindRootCloseHandlers();
+      } else {
+        this.bindRootCloseHandlers();
+      }
+    }
   }
 
   render() {

--- a/test/RootCloseSpec.js
+++ b/test/RootCloseSpec.js
@@ -81,6 +81,38 @@ describe('RootCloseWrapper', function () {
       expect(spy).to.not.have.been.called;
     });
 
+    it('should close when disabled removed on updated', () => {
+      const spy = sinon.spy();
+
+      const wrapper = render(
+        <RootCloseWrapper onRootClose={spy} event={eventProp} >
+          <div id='my-div'>hello there</div>
+        </RootCloseWrapper>
+      , mountPoint);
+
+      wrapper.renderWithProps({ onRootClose: spy, event: eventProp, disabled: undefined });
+
+      simulant.fire(document.body, eventName);
+
+      expect(spy).to.have.been.called;
+    });
+
+    it('should not close when disabled added on update', () => {
+
+      let spy = sinon.spy();
+      const wrapper = render(
+        <RootCloseWrapper onRootClose={spy} event={eventProp}>
+          <div id='my-div'>hello there</div>
+        </RootCloseWrapper>
+      , mountPoint);
+
+      wrapper.renderWithProps({ onRootClose: spy, event: eventProp, disabled: true });
+
+      simulant.fire(document.body, eventName);
+
+      expect(spy).to.not.have.been.called;
+    });
+
     it('should close when inside another RootCloseWrapper', () => {
       let outerSpy = sinon.spy();
       let innerSpy = sinon.spy();


### PR DESCRIPTION
Hi all. 

I've come here from https://github.com/react-bootstrap/react-bootstrap/issues/1808 
On those issue @taion asked to rewrite `RootCloseWrapper` which helps not to remount child components on `DropdownMenu`. The solution of react-bootstrap issue is properly binding/unbinding root close handlers. 

The idea was tested with react-bootstrap and it works! You could check it here (https://github.com/Zapix/react-bootstrap/tree/overlay-test). 
So if everything is ok with current PR then I'm able to fix DropdownMenu issue.

Thank you. 
