### PR TITLE
Expose rootCloseWrapper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export Overlay from './Overlay';
 export Portal from './Portal';
 export Position from './Position';
 export Transition from './Transition';
+export RootCloseWrapper from './RootCloseWrapper';


### PR DESCRIPTION
## What is this?

We're doing our own popover component. And we want to accomplish 3 things with this component:
1. Be able to render outside of current React Element. Like in body. Done with `react-overlays/Portal`;
2. Close all popovers when clicking on the page. Done with `react-overlays/RootCloseWrrapper`
3. Position popover. Done with [popper.js](https://popper.js.org/)
## Why use Popper.js instead of Position component

Popper offer more placement options like `bottom-start`, `bottom-end`, `left-start`,...
Also has the concept of boundaries to react on scroll of an arbitrary element.

We think `react-overlays/Position` is fine but doesn't meet our requirements.
## It this posible?

It would be posible to expose in `RootCloseWrapper`? This way we can use a `Portal` and a `RootCloseWrapper` together which is an`Overlay` component. The problem is that `Overlay` component is using `react-overlays/Position` and we don't want that.

Thank you so much for this great package! :clap:
