### PR TITLE
Fix rootClose on unmounting components

### DIFF
--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -44,8 +44,11 @@ export default class RootCloseWrapper extends React.Component {
   bindRootCloseHandlers() {
     const doc = ownerDocument(this);
 
+    // Use capture for this listener so it fires before React's listener, to
+    // avoid false positives in the contains() check below if the target DOM
+    // element is removed in the React mouse callback.
     this._onDocumentMouseListener =
-      addEventListener(doc, this.props.event, this.handleDocumentMouse);
+      addEventListener(doc, this.props.event, this.handleDocumentMouse, true);
 
     this._onDocumentKeyupListener =
       addEventListener(doc, 'keyup', this.handleDocumentKeyUp);
@@ -66,8 +69,7 @@ export default class RootCloseWrapper extends React.Component {
       this.props.disabled ||
       isModifiedEvent(e) ||
       !isLeftClickEvent(e) ||
-      contains(ReactDOM.findDOMNode(this), e.target) ||
-      !contains(ownerDocument(this), e.target)
+      contains(ReactDOM.findDOMNode(this), e.target)
     ) {
       return;
     }

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -66,7 +66,8 @@ export default class RootCloseWrapper extends React.Component {
       this.props.disabled ||
       isModifiedEvent(e) ||
       !isLeftClickEvent(e) ||
-      contains(ReactDOM.findDOMNode(this), e.target)
+      contains(ReactDOM.findDOMNode(this), e.target) ||
+      !contains(ownerDocument(this), e.target)
     ) {
       return;
     }

--- a/src/utils/addEventListener.js
+++ b/src/utils/addEventListener.js
@@ -1,11 +1,11 @@
 import addEventListener from 'dom-helpers/events/on';
 import removeEventListener from 'dom-helpers/events/off';
 
-export default function (node, event, handler) {
-  addEventListener(node, event, handler);
+export default function (node, event, handler, capture) {
+  addEventListener(node, event, handler, capture);
   return {
     remove(){
-      removeEventListener(node, event, handler);
+      removeEventListener(node, event, handler, capture);
     }
   };
 }


### PR DESCRIPTION
Most likely React unmounted the target in response to some other click.

@jquense This logic is not ideal but probably fine in practice? What do you think?