### PR TITLE
Resolves #141 Expose DOM event for close events from the RootCloseWrapper.

### DIFF
--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -79,15 +79,15 @@ export default class RootCloseWrapper extends React.Component {
     );
   };
 
-  handleMouse = () => {
+  handleMouse = (e) => {
     if (!this.preventMouseRootClose && this.props.onRootClose) {
-      this.props.onRootClose();
+      this.props.onRootClose(e);
     }
   };
 
   handleKeyUp = (e) => {
     if (e.keyCode === 27 && this.props.onRootClose) {
-      this.props.onRootClose();
+      this.props.onRootClose(e);
     }
   };
 

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -5,6 +5,8 @@ import ReactDOM from 'react-dom';
 import addEventListener from './utils/addEventListener';
 import ownerDocument from './utils/ownerDocument';
 
+const escapeKeyCode = 27;
+
 function isLeftClickEvent(event) {
   return event.button === 0;
 }
@@ -86,7 +88,7 @@ export default class RootCloseWrapper extends React.Component {
   };
 
   handleKeyUp = (e) => {
-    if (e.keyCode === 27 && this.props.onRootClose) {
+    if (e.keyCode === escapeKeyCode && this.props.onRootClose) {
       this.props.onRootClose(e);
     }
   };

--- a/test/RootCloseWrapperSpec.js
+++ b/test/RootCloseWrapperSpec.js
@@ -4,6 +4,8 @@ import RootCloseWrapper from '../src/RootCloseWrapper';
 import { render } from './helpers';
 import simulant from 'simulant';
 
+const escapeKeyCode = 27;
+
 describe('RootCloseWrapper', function () {
   let mountPoint;
 
@@ -29,10 +31,6 @@ describe('RootCloseWrapper', function () {
     shouldCloseOn('mousedown', 'mousedown');
   });
 
-  describe('using keyup event', () => {
-    shouldCloseOnKeyUp('keyup');
-  });
-
   function shouldCloseOn(eventProp, eventName) {
     it('should close when clicked outside', () => {
       let spy = sinon.spy();
@@ -50,7 +48,7 @@ describe('RootCloseWrapper', function () {
 
       expect(spy).to.have.been.calledOnce;
 
-      assert.oneOf(spy.getCall(0).args[0].type, ['click', 'mousedown'] );
+      expect(innerSpy.getCall(0).args[0].type).to.be.oneOf(['click', 'mousedown']);
     });
 
     it('should not close when right-clicked outside', () => {
@@ -107,11 +105,11 @@ describe('RootCloseWrapper', function () {
       expect(outerSpy).to.have.not.been.called;
       expect(innerSpy).to.have.been.calledOnce;
 
-      assert.oneOf(innerSpy.getCall(0).args[0].type, ['click', 'mousedown']  );
+      expect(innerSpy.getCall(0).args[0].type).to.be.oneOf(['click', 'mousedown'])
     });
   }
 
-  function shouldCloseOnKeyUp(eventName) {
+  describe('using keyup event', () => {
     it('should close when escape keyup', () => {
       let spy = sinon.spy();
       render(
@@ -122,37 +120,41 @@ describe('RootCloseWrapper', function () {
 
       expect(spy).to.not.have.been.called;
 
-      simulant.fire(document.body, eventName, {keyCode: 27});
+      simulant.fire(document.body, 'keyup', {keyCode: escapeKeyCode});
 
       expect(spy).to.have.been.calledOnce;
 
-      assert.equal(spy.getCall(0).args[0].type, 'keyup' );
-      assert.equal(spy.getCall(0).args[0].keyCode, 27 );
+      expect(spy.getCall(0).args.length).to.be.eql(1);
+      expect(spy.getCall(0).args[0]).to.not.be.undefined;
+      expect(spy.getCall(0).args[0]).to.not.be.null;
+      expect(spy.getCall(0).args[0].keyCode).to.be.eql(escapeKeyCode);
+      expect(spy.getCall(0).args[0].type).to.be.eql('keyup');
     });
 
-  // TODO: Update code to make this pass
-  //   it('should close when inside another RootCloseWrapper', () => {
-  //         let outerSpy = sinon.spy();
-  //         let innerSpy = sinon.spy();
+    it('should close when inside another RootCloseWrapper', () => {
+      let outerSpy = sinon.spy();
+      let innerSpy = sinon.spy();
 
-  //         render(
-  //           <RootCloseWrapper onRootClose={outerSpy}>
-  //             <div>
-  //               <div id='my-div'>hello there</div>
-  //               <RootCloseWrapper onRootClose={innerSpy}>
-  //                 <div id='my-other-div'>hello there</div>
-  //               </RootCloseWrapper>
-  //             </div>
-  //           </RootCloseWrapper>
-  //         );
+      render(
+        <RootCloseWrapper onRootClose={outerSpy}>
+          <div>
+            <div id='my-div'>hello there</div>
+            <RootCloseWrapper onRootClose={innerSpy}>
+              <div id='my-other-div'>hello there</div>
+            </RootCloseWrapper>
+          </div>
+        </RootCloseWrapper>
+      );
 
-  //         simulant.fire(document.body, eventName, {keyCode: 27});
+      simulant.fire(document.body, 'keyup', {keyCode: escapeKeyCode});
 
-  //         expect(outerSpy).to.have.not.been.called;
-  //         expect(innerSpy).to.have.been.calledOnce;
+      // TODO: Update library to make this expectation pass.
+      // expect(outerSpy).to.have.not.been.called;
+      expect(innerSpy).to.have.been.calledOnce;
 
-  //         assert.equal(innerSpy.getCall(0).args[0].type, 'keyup' );
-  //         assert.equal(innerSpy.getCall(0).args[0].keyCode, 27 );
-  //       });
-  }
+      expect(innerSpy.getCall(0).args.length).to.be.eql(1);
+      expect(innerSpy.getCall(0).args[0].keyCode).to.be.eql(escapeKeyCode);
+      expect(innerSpy.getCall(0).args[0].type).to.be.eql('keyup');
+    });
+  });
 });

--- a/test/RootCloseWrapperSpec.js
+++ b/test/RootCloseWrapperSpec.js
@@ -48,7 +48,7 @@ describe('RootCloseWrapper', function () {
 
       expect(spy).to.have.been.calledOnce;
 
-      expect(innerSpy.getCall(0).args[0].type).to.be.oneOf(['click', 'mousedown']);
+      expect(spy.getCall(0).args[0].type).to.be.oneOf(['click', 'mousedown']);
     });
 
     it('should not close when right-clicked outside', () => {

--- a/test/RootCloseWrapperSpec.js
+++ b/test/RootCloseWrapperSpec.js
@@ -124,11 +124,9 @@ describe('RootCloseWrapper', function () {
 
       expect(spy).to.have.been.calledOnce;
 
-      expect(spy.getCall(0).args.length).to.be.eql(1);
-      expect(spy.getCall(0).args[0]).to.not.be.undefined;
-      expect(spy.getCall(0).args[0]).to.not.be.null;
-      expect(spy.getCall(0).args[0].keyCode).to.be.eql(escapeKeyCode);
-      expect(spy.getCall(0).args[0].type).to.be.eql('keyup');
+      expect(spy.getCall(0).args.length).to.be.equal(1);
+      expect(spy.getCall(0).args[0].keyCode).to.be.equal(escapeKeyCode);
+      expect(spy.getCall(0).args[0].type).to.be.equal('keyup');
     });
 
     it('should close when inside another RootCloseWrapper', () => {
@@ -148,13 +146,13 @@ describe('RootCloseWrapper', function () {
 
       simulant.fire(document.body, 'keyup', {keyCode: escapeKeyCode});
 
-      // TODO: Update library to make this expectation pass.
+      // TODO: Update to match expectations.
       // expect(outerSpy).to.have.not.been.called;
       expect(innerSpy).to.have.been.calledOnce;
 
-      expect(innerSpy.getCall(0).args.length).to.be.eql(1);
-      expect(innerSpy.getCall(0).args[0].keyCode).to.be.eql(escapeKeyCode);
-      expect(innerSpy.getCall(0).args[0].type).to.be.eql('keyup');
+      expect(innerSpy.getCall(0).args.length).to.be.equal(1);
+      expect(innerSpy.getCall(0).args[0].keyCode).to.be.equal(escapeKeyCode);
+      expect(innerSpy.getCall(0).args[0].type).to.be.equal('keyup');
     });
   });
 });

--- a/test/RootCloseWrapperSpec.js
+++ b/test/RootCloseWrapperSpec.js
@@ -29,6 +29,10 @@ describe('RootCloseWrapper', function () {
     shouldCloseOn('mousedown', 'mousedown');
   });
 
+  describe('using keyup event', () => {
+    shouldCloseOnKeyUp('keyup');
+  });
+
   function shouldCloseOn(eventProp, eventName) {
     it('should close when clicked outside', () => {
       let spy = sinon.spy();
@@ -45,6 +49,8 @@ describe('RootCloseWrapper', function () {
       simulant.fire(document.body, eventName);
 
       expect(spy).to.have.been.calledOnce;
+
+      assert.oneOf(spy.getCall(0).args[0].type, ['click', 'mousedown'] );
     });
 
     it('should not close when right-clicked outside', () => {
@@ -100,6 +106,53 @@ describe('RootCloseWrapper', function () {
 
       expect(outerSpy).to.have.not.been.called;
       expect(innerSpy).to.have.been.calledOnce;
+
+      assert.oneOf(innerSpy.getCall(0).args[0].type, ['click', 'mousedown']  );
     });
+  }
+
+  function shouldCloseOnKeyUp(eventName) {
+    it('should close when escape keyup', () => {
+      let spy = sinon.spy();
+      render(
+        <RootCloseWrapper onRootClose={spy}>
+          <div id='my-div'>hello there</div>
+        </RootCloseWrapper>
+      );
+
+      expect(spy).to.not.have.been.called;
+
+      simulant.fire(document.body, eventName, {keyCode: 27});
+
+      expect(spy).to.have.been.calledOnce;
+
+      assert.equal(spy.getCall(0).args[0].type, 'keyup' );
+      assert.equal(spy.getCall(0).args[0].keyCode, 27 );
+    });
+
+  // TODO: Update code to make this pass
+  //   it('should close when inside another RootCloseWrapper', () => {
+  //         let outerSpy = sinon.spy();
+  //         let innerSpy = sinon.spy();
+
+  //         render(
+  //           <RootCloseWrapper onRootClose={outerSpy}>
+  //             <div>
+  //               <div id='my-div'>hello there</div>
+  //               <RootCloseWrapper onRootClose={innerSpy}>
+  //                 <div id='my-other-div'>hello there</div>
+  //               </RootCloseWrapper>
+  //             </div>
+  //           </RootCloseWrapper>
+  //         );
+
+  //         simulant.fire(document.body, eventName, {keyCode: 27});
+
+  //         expect(outerSpy).to.have.not.been.called;
+  //         expect(innerSpy).to.have.been.calledOnce;
+
+  //         assert.equal(innerSpy.getCall(0).args[0].type, 'keyup' );
+  //         assert.equal(innerSpy.getCall(0).args[0].keyCode, 27 );
+  //       });
   }
 });


### PR DESCRIPTION
Expose the DOM event through the callback. Allows the callback to determine how the RootCloseWrapper was closed, by `click` or by `keyup` of `esc`.

See #141