### PR TITLE
Modal: add restoreFocus option

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -158,6 +158,12 @@ const Modal = React.createClass({
      * accessible to assistive technologies, like screen readers.
      */
     enforceFocus: React.PropTypes.bool,
+    
+    /**
+     * When `true` The modal will restore focus to previously focused element once
+     * modal is hidden
+     */
+    restoreFocus: React.PropTypes.bool,
 
     /**
      * Callback fired before the Modal transitions in
@@ -205,6 +211,7 @@ const Modal = React.createClass({
       keyboard: true,
       autoFocus: true,
       enforceFocus: true,
+      restoreFocus: true,
       onHide: noop,
       manager: modalManager,
       renderBackdrop: (props) => <div {...props} />
@@ -405,7 +412,9 @@ const Modal = React.createClass({
 
     this._onFocusinListener.remove();
 
-    this.restoreLastFocus();
+    if (this.props.restoreFocus) {
+      this.restoreLastFocus();
+    }
   },
 
   setMountNode(ref) {


### PR DESCRIPTION
Allow to specify if last focus should be restored after modal is hidden.

I suppose it may be possible and appreciated to write test for it, like those ones https://github.com/react-bootstrap/react-overlays/blob/master/test/ModalSpec.js#L312, but before I spend a lot of time on it, I'd like to be sure you're OK with this change.

The thing is, it's not always desired to call `focus` method on thing that was `activeElement` at the moment modal was shown. I can imagine it's valid in most of use cases, however in some it's not and... I did things I'm really, really ashamed of to workaround this. Please, let my conscience to be cleared.