### PR TITLE
Expose RootCloseWrapper as part of public API

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -11,6 +11,7 @@ import OverlaySource from '../webpack/example-loader!./Overlay';
 import PortalSource from '../webpack/example-loader!./Portal';
 import PositionSource from '../webpack/example-loader!./Position';
 import TransitionSource from '../webpack/example-loader!./Transition';
+import RootCloseWrapperSource from '../webpack/example-loader!./RootCloseWrapper';
 
 import AffixMetadata from 'component-metadata-loader?pitch!react-overlays/Affix';
 import AutoAffixMetadata from 'component-metadata-loader?pitch!react-overlays/AutoAffix';
@@ -19,6 +20,7 @@ import PositionMetadata from 'component-metadata-loader?pitch!react-overlays/Pos
 import OverlayMetadata from 'component-metadata-loader?pitch!react-overlays/Overlay';
 import ModalMetadata from 'component-metadata-loader?pitch!react-overlays/Modal';
 import TransitionMetadata from 'component-metadata-loader?pitch!react-overlays/Transition';
+import RootCloseWrapperMetadata from 'component-metadata-loader?pitch!react-overlays/RootCloseWrapper';
 
 import * as ReactOverlays from 'react-overlays';
 import getOffset from 'dom-helpers/query/offset';
@@ -82,6 +84,7 @@ const Example = React.createClass({
             <li><a href='#position'>Position</a></li>
             <li><a href='#overlay'>Overlay</a></li>
             <li><a href='#affixes'>Affixes</a></li>
+            <li><a href='#rootclosewrapper'>RootCloseWrapper</a></li>
           </ul>
         </article>
         <main className='col-md-10'>
@@ -154,6 +157,17 @@ const Example = React.createClass({
             <PropTable
               component='AutoAffix'
               metadata={AutoAffixMetadata}
+            />
+          </section>
+          <section>
+            <h2 className='page-header'>
+              <Anchor>RootCloseWrapper</Anchor>
+            </h2>
+            <p dangerouslySetInnerHTML={{__html: RootCloseWrapperMetadata.RootCloseWrapper.descHtml }}/>
+            <ExampleEditor codeText={RootCloseWrapperSource} />
+            <PropTable
+              component='RootCloseWrapper'
+              metadata={RootCloseWrapperMetadata}
             />
           </section>
         </main>

--- a/examples/RootCloseWrapper.js
+++ b/examples/RootCloseWrapper.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import Button from 'react-bootstrap/lib/Button';
+import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
+
+class RootCloseWrapperExample extends React.Component {
+  constructor(...args){
+    super(...args);
+    this.state = { show: false };
+
+    this.show = ()=> this.setState({ show: true });
+    this.hide = ()=> this.setState({ show: false });
+  }
+
+  render() {
+    return (
+      <div className='rootclosewrapper-example'>
+        <Button bsStyle='primary' onClick={this.show}>
+          Render RootCloseWrapper
+        </Button>
+        { this.state.show &&
+          <RootCloseWrapper onRootClose={this.hide}>
+            <div className='panel panel-default'>
+              <div className='panel-body'>
+                <span>Click anywhere to dismiss me!</span>
+              </div>
+            </div>
+          </RootCloseWrapper>
+        }
+      </div>
+    );
+  }
+}
+
+export default RootCloseWrapperExample;

--- a/examples/styles.less
+++ b/examples/styles.less
@@ -168,7 +168,8 @@ h4 a:focus .anchor-icon {
 
 .modal-example,
 .portal-example,
-.overlay-example, {
+.overlay-example,
+.rootclosewrapper-example {
   text-align: center;
 }
 
@@ -183,7 +184,8 @@ h4 a:focus .anchor-icon {
   }
 }
 
-.portal-example {
+.portal-example,
+.rootclosewrapper-example {
   button {
     margin-bottom: 10px;
   }

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -17,7 +17,8 @@ function isModifiedEvent(event) {
 
 /**
  * The `<RootCloseWrapper/>` registers your callback on the document when rendered. Powers the
- * `<Overlay/>` component.
+ * `<Overlay/>` component. This is used achieve modal style behavior where your callback is
+ * triggered when the user tries to interact with the rest of the document or hits the `esc` key.
  */
 class RootCloseWrapper extends React.Component {
   constructor(props, context) {
@@ -106,7 +107,7 @@ RootCloseWrapper.displayName = 'RootCloseWrapper';
 
 RootCloseWrapper.propTypes = {
   /**
-   * Callback fired after click or mousedown.
+   * Callback fired after click or mousedown. Also triggers when user hits `esc`.
    */
   onRootClose: React.PropTypes.func,
   /**
@@ -114,8 +115,7 @@ RootCloseWrapper.propTypes = {
    */
   children: React.PropTypes.element,
   /**
-   * Disable the the RootCloseWrapper, preventing it from triggering
-   * `onRootClose`.
+   * Disable the the RootCloseWrapper, preventing it from triggering `onRootClose`.
    */
   disabled: React.PropTypes.bool,
   /**

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -15,7 +15,11 @@ function isModifiedEvent(event) {
   return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
 }
 
-export default class RootCloseWrapper extends React.Component {
+/**
+ * The `<RootCloseWrapper/>` registers your callback on the document when rendered. Powers the
+ * `<Overlay/>` component.
+ */
+class RootCloseWrapper extends React.Component {
   constructor(props, context) {
     super(props, context);
 
@@ -101,16 +105,21 @@ export default class RootCloseWrapper extends React.Component {
 RootCloseWrapper.displayName = 'RootCloseWrapper';
 
 RootCloseWrapper.propTypes = {
+  /**
+   * Callback fired after click or mousedown.
+   */
   onRootClose: React.PropTypes.func,
+  /**
+   * Children to render.
+   */
   children: React.PropTypes.element,
-
   /**
    * Disable the the RootCloseWrapper, preventing it from triggering
    * `onRootClose`.
    */
   disabled: React.PropTypes.bool,
   /**
-   * Choose which document mouse event to bind to
+   * Choose which document mouse event to bind to.
    */
   event: React.PropTypes.oneOf(['click', 'mousedown'])
 };
@@ -118,3 +127,5 @@ RootCloseWrapper.propTypes = {
 RootCloseWrapper.defaultProps = {
   event: 'click'
 };
+
+export default RootCloseWrapper;

--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ export Overlay from './Overlay';
 export Portal from './Portal';
 export Position from './Position';
 export Transition from './Transition';
+export RootCloseWrapper from './RootCloseWrapper';


### PR DESCRIPTION
This PR exposes `<RootCloseWrapper/>` as part of the public API and adds examples. Resolves #77.

Thanks to the maintainers, this package has been super helpful ❤️ 