### PR TITLE
Portal: Move _renderOverlay() to component render

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -24,14 +24,6 @@ let Portal = React.createClass({
     ])
   },
 
-  componentDidMount() {
-    this._renderOverlay();
-  },
-
-  componentDidUpdate() {
-    this._renderOverlay();
-  },
-
   componentWillReceiveProps(nextProps) {
     if (this._overlayTarget && nextProps.container !== this.props.container) {
       this._portalContainerNode.removeChild(this._overlayTarget);
@@ -89,6 +81,7 @@ let Portal = React.createClass({
   },
 
   render() {
+    this._renderOverlay();
     return null;
   },
 


### PR DESCRIPTION
As far as I can see, there's no reason to use componentDidMount and componentDidUpdate to render the overlay. Might as well render it on the render function.

Also, this will make it not reliant on the order of the lifecycle which will avoid problems like [developit/preact-compat#312](https://github.com/developit/preact-compat/issues/312)