### PR TITLE
Import Transition into Modal to fix default property value

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -6,6 +6,7 @@ import elementType from 'react-prop-types/lib/elementType';
 
 import Portal from './Portal';
 import ModalManager from './ModalManager';
+import Transition from './Transition';
 
 import ownerDocument from './utils/ownerDocument';
 import addEventListener from './utils/addEventListener';


### PR DESCRIPTION
[Here](https://github.com/react-bootstrap/react-overlays/blob/master/src/Modal.js#L243) `<Modal />` tries to fallback to `<Transition />`, but it was never imported. So it works like: `prop = undefined || undefined`. Because of this, `renderBackdrop()` will never work without passing `transition` property to  the `<Modal />`.

Probably proper way will be to put `<Transition />` to `getDefaultProps()`, but I think it's better to change as less code as possible. 