### PR TITLE
Add RootCloseWrapper's event support to Overlay

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -76,7 +76,7 @@ class Overlay extends React.Component {
     }
 
     // This goes after everything else because it adds a wrapping div.
-    if (rootClose) {      
+    if (rootClose) {
       child = (
         <RootCloseWrapper
           onRootClose={props.onHide}

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -77,8 +77,13 @@ class Overlay extends React.Component {
 
     // This goes after everything else because it adds a wrapping div.
     if (rootClose) {
+      let { event } = props;
+      
       child = (
-        <RootCloseWrapper onRootClose={props.onHide}>
+        <RootCloseWrapper
+          onRootClose={props.onHide}
+          event={event}
+        >
           {child}
         </RootCloseWrapper>
       );
@@ -163,7 +168,12 @@ Overlay.propTypes = {
   /**
    * Callback fired after the Overlay finishes transitioning out
    */
-  onExited: React.PropTypes.func
+  onExited: React.PropTypes.func,
+
+  /**
+   * Choose which document mouse event to bind the RootCloseWrapper to.
+   */
+  event: RootCloseWrapper.propTypes.event
 };
 
 

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -76,13 +76,11 @@ class Overlay extends React.Component {
     }
 
     // This goes after everything else because it adds a wrapping div.
-    if (rootClose) {
-      let { event } = props;
-      
+    if (rootClose) {      
       child = (
         <RootCloseWrapper
           onRootClose={props.onHide}
-          event={event}
+          event={props.event}
         >
           {child}
         </RootCloseWrapper>


### PR DESCRIPTION
I used the same style to pass the prop this time.