### PR TITLE
Use prop-types instead of React.PropTypes

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM, { findDOMNode } from 'react-dom';
+import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/lib/Button';
 import Playground from '@monastic.panic/component-playground/Playground';
 
@@ -34,7 +35,7 @@ const scope = {
 
 const Anchor = React.createClass({
   propTypes: {
-    id: React.PropTypes.string
+    id: PropTypes.string
   },
   render() {
     let id = this.props.id || this.props.children.toLowerCase().replace(/\s+/gi, '_');
@@ -50,7 +51,7 @@ const Anchor = React.createClass({
 
 const ExampleEditor = React.createClass({
   propTypes: {
-    codeText: React.PropTypes.string
+    codeText: PropTypes.string
   },
   render() {
     return (

--- a/examples/PropTable.js
+++ b/examples/PropTable.js
@@ -1,5 +1,6 @@
 import merge from 'lodash/merge';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Label from 'react-bootstrap/lib/Label';
 import Table from 'react-bootstrap/lib/Table';
 
@@ -29,7 +30,7 @@ function getPropsData(componentData, metadata){
 const PropTable = React.createClass({
 
   contextTypes: {
-    metadata: React.PropTypes.object
+    metadata: PropTypes.object
   },
 
   componentWillMount(){

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "dom-helpers": "^3.2.0",
+    "prop-types": "^15.5.8",
     "react-prop-types": "^0.4.0",
     "warning": "^3.0.0"
   }

--- a/src/Affix.js
+++ b/src/Affix.js
@@ -6,6 +6,7 @@ import getScrollTop from 'dom-helpers/query/scrollTop';
 import requestAnimationFrame from 'dom-helpers/util/requestAnimationFrame';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 import addEventListener from './utils/addEventListener';
 import getDocumentHeight from './utils/getDocumentHeight';
@@ -180,75 +181,75 @@ Affix.propTypes = {
   /**
    * Pixels to offset from top of screen when calculating position
    */
-  offsetTop: React.PropTypes.number,
+  offsetTop: PropTypes.number,
 
   /**
    * When affixed, pixels to offset from top of viewport
    */
-  viewportOffsetTop: React.PropTypes.number,
+  viewportOffsetTop: PropTypes.number,
 
   /**
    * Pixels to offset from bottom of screen when calculating position
    */
-  offsetBottom: React.PropTypes.number,
+  offsetBottom: PropTypes.number,
 
   /**
    * CSS class or classes to apply when at top
    */
-  topClassName: React.PropTypes.string,
+  topClassName: PropTypes.string,
 
   /**
    * Style to apply when at top
    */
-  topStyle: React.PropTypes.object,
+  topStyle: PropTypes.object,
 
   /**
    * CSS class or classes to apply when affixed
    */
-  affixClassName: React.PropTypes.string,
+  affixClassName: PropTypes.string,
   /**
    * Style to apply when affixed
    */
-  affixStyle: React.PropTypes.object,
+  affixStyle: PropTypes.object,
 
   /**
    * CSS class or classes to apply when at bottom
    */
-  bottomClassName: React.PropTypes.string,
+  bottomClassName: PropTypes.string,
 
   /**
    * Style to apply when at bottom
    */
-  bottomStyle: React.PropTypes.object,
+  bottomStyle: PropTypes.object,
 
   /**
    * Callback fired when the right before the `affixStyle` and `affixStyle` props are rendered
    */
-  onAffix: React.PropTypes.func,
+  onAffix: PropTypes.func,
   /**
    * Callback fired after the component `affixStyle` and `affixClassName` props have been rendered.
    */
-  onAffixed: React.PropTypes.func,
+  onAffixed: PropTypes.func,
 
   /**
    * Callback fired when the right before the `topStyle` and `topClassName` props are rendered
    */
-  onAffixTop: React.PropTypes.func,
+  onAffixTop: PropTypes.func,
 
   /**
    * Callback fired after the component `topStyle` and `topClassName` props have been rendered.
    */
-  onAffixedTop: React.PropTypes.func,
+  onAffixedTop: PropTypes.func,
 
   /**
    * Callback fired when the right before the `bottomStyle` and `bottomClassName` props are rendered
    */
-  onAffixBottom: React.PropTypes.func,
+  onAffixBottom: PropTypes.func,
 
   /**
    * Callback fired after the component `bottomStyle` and `bottomClassName` props have been rendered.
    */
-  onAffixedBottom: React.PropTypes.func
+  onAffixedBottom: PropTypes.func
 };
 
 Affix.defaultProps = {

--- a/src/AutoAffix.js
+++ b/src/AutoAffix.js
@@ -1,6 +1,7 @@
 import getOffset from 'dom-helpers/query/offset';
 import requestAnimationFrame from 'dom-helpers/util/requestAnimationFrame';
 import React from 'react';
+import PropTypes from 'prop-types';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 
 import Affix from './Affix';
@@ -154,14 +155,14 @@ AutoAffix.propTypes = {
    * The logical container node or component for determining offset from bottom
    * of viewport, or a function that returns it
    */
-  container: React.PropTypes.oneOfType([
+  container: PropTypes.oneOfType([
     componentOrElement,
-    React.PropTypes.func
+    PropTypes.func
   ]),
   /**
    * Automatically set width when affixed
    */
-  autoWidth: React.PropTypes.bool
+  autoWidth: PropTypes.bool
 };
 
 // This intentionally doesn't inherit default props from `<Affix>`, so that the

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,5 +1,6 @@
 /*eslint-disable react/prop-types */
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 import elementType from 'react-prop-types/lib/elementType';
@@ -45,7 +46,7 @@ const Modal = React.createClass({
     /**
      * Set the visibility of the Modal
      */
-    show: React.PropTypes.bool,
+    show: PropTypes.bool,
 
     /**
      * A Node, Component instance, or function that returns either. The Modal is appended to it's container element.
@@ -53,15 +54,15 @@ const Modal = React.createClass({
      * For the sake of assistive technologies, the container should usually be the document body, so that the rest of the
      * page content can be placed behind a virtual backdrop as well as a visual one.
      */
-    container: React.PropTypes.oneOfType([
+    container: PropTypes.oneOfType([
       componentOrElement,
-      React.PropTypes.func
+      PropTypes.func
     ]),
 
     /**
      * A callback fired when the Modal is opening.
      */
-    onShow: React.PropTypes.func,
+    onShow: PropTypes.func,
 
     /**
      * A callback fired when either the backdrop is clicked, or the escape key is pressed.
@@ -69,14 +70,14 @@ const Modal = React.createClass({
      * The `onHide` callback only signals intent from the Modal,
      * you must actually set the `show` prop to `false` for the Modal to close.
      */
-    onHide: React.PropTypes.func,
+    onHide: PropTypes.func,
 
     /**
      * Include a backdrop component.
      */
-    backdrop: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.oneOf(['static'])
+    backdrop: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(['static'])
     ]),
 
     /**
@@ -87,38 +88,38 @@ const Modal = React.createClass({
      *  renderBackdrop={props => <MyBackdrop {...props} />}
      * ```
      */
-    renderBackdrop: React.PropTypes.func,
+    renderBackdrop: PropTypes.func,
 
     /**
      * A callback fired when the escape key, if specified in `keyboard`, is pressed.
      */
-    onEscapeKeyUp: React.PropTypes.func,
+    onEscapeKeyUp: PropTypes.func,
 
     /**
      * A callback fired when the backdrop, if specified, is clicked.
      */
-    onBackdropClick: React.PropTypes.func,
+    onBackdropClick: PropTypes.func,
 
     /**
      * A style object for the backdrop component.
      */
-    backdropStyle: React.PropTypes.object,
+    backdropStyle: PropTypes.object,
 
     /**
      * A css class or classes for the backdrop component.
      */
-    backdropClassName: React.PropTypes.string,
+    backdropClassName: PropTypes.string,
 
     /**
      * A css class or set of classes applied to the modal container when the modal is open,
      * and removed when it is closed.
      */
-    containerClassName: React.PropTypes.string,
+    containerClassName: PropTypes.string,
 
     /**
      * Close the modal when escape key is pressed
      */
-    keyboard: React.PropTypes.bool,
+    keyboard: PropTypes.bool,
 
     /**
      * A `<Transition/>` component to use for the dialog and backdrop components.
@@ -131,7 +132,7 @@ const Modal = React.createClass({
      *
      * See the Transition `timeout` prop for more infomation.
      */
-    dialogTransitionTimeout: React.PropTypes.number,
+    dialogTransitionTimeout: PropTypes.number,
 
     /**
      * The `timeout` of the backdrop transition if specified. This number is used to
@@ -139,7 +140,7 @@ const Modal = React.createClass({
      *
      * See the Transition `timeout` prop for more infomation.
      */
-    backdropTransitionTimeout: React.PropTypes.number,
+    backdropTransitionTimeout: PropTypes.number,
 
     /**
      * When `true` The modal will automatically shift focus to itself when it opens, and
@@ -149,7 +150,7 @@ const Modal = React.createClass({
      * Generally this should never be set to `false` as it makes the Modal less
      * accessible to assistive technologies, like screen readers.
      */
-    autoFocus: React.PropTypes.bool,
+    autoFocus: PropTypes.bool,
 
     /**
      * When `true` The modal will prevent focus from leaving the Modal while open.
@@ -157,49 +158,49 @@ const Modal = React.createClass({
      * Generally this should never be set to `false` as it makes the Modal less
      * accessible to assistive technologies, like screen readers.
      */
-    enforceFocus: React.PropTypes.bool,
+    enforceFocus: PropTypes.bool,
     
     /**
      * When `true` The modal will restore focus to previously focused element once
      * modal is hidden
      */
-    restoreFocus: React.PropTypes.bool,
+    restoreFocus: PropTypes.bool,
 
     /**
      * Callback fired before the Modal transitions in
      */
-    onEnter: React.PropTypes.func,
+    onEnter: PropTypes.func,
 
     /**
      * Callback fired as the Modal begins to transition in
      */
-    onEntering: React.PropTypes.func,
+    onEntering: PropTypes.func,
 
     /**
      * Callback fired after the Modal finishes transitioning in
      */
-    onEntered: React.PropTypes.func,
+    onEntered: PropTypes.func,
 
     /**
      * Callback fired right before the Modal transitions out
      */
-    onExit: React.PropTypes.func,
+    onExit: PropTypes.func,
 
     /**
      * Callback fired as the Modal begins to transition out
      */
-    onExiting: React.PropTypes.func,
+    onExiting: PropTypes.func,
 
     /**
      * Callback fired after the Modal finishes transitioning out
      */
-    onExited: React.PropTypes.func,
+    onExited: PropTypes.func,
 
     /**
      * A ModalManager instance used to track and manage the state of open
      * Modals. Useful when customizing how modals interact within a container
      */
-    manager: React.PropTypes.object.isRequired,
+    manager: PropTypes.object.isRequired,
   },
 
   getDefaultProps() {

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Portal from './Portal';
 import Position from './Position';
 import RootCloseWrapper from './RootCloseWrapper';
@@ -107,12 +108,12 @@ Overlay.propTypes = {
   /**
    * Set the visibility of the Overlay
    */
-  show: React.PropTypes.bool,
+  show: PropTypes.bool,
 
   /**
    * Specify whether the overlay should trigger `onHide` when the user clicks outside the overlay
    */
-  rootClose: React.PropTypes.bool,
+  rootClose: PropTypes.bool,
 
   /**
    * A Callback fired by the Overlay when it wishes to be hidden.
@@ -122,7 +123,7 @@ Overlay.propTypes = {
    * @type func
    */
   onHide(props, ...args) {
-    let propType = React.PropTypes.func;
+    let propType = PropTypes.func;
     if (props.rootClose) {
       propType = propType.isRequired;
     }
@@ -138,32 +139,32 @@ Overlay.propTypes = {
   /**
    * Callback fired before the Overlay transitions in
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
 
   /**
    * Callback fired as the Overlay begins to transition in
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
 
   /**
    * Callback fired after the Overlay finishes transitioning in
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
 
   /**
    * Callback fired right before the Overlay transitions out
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
 
   /**
    * Callback fired as the Overlay begins to transition out
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
 
   /**
    * Callback fired after the Overlay finishes transitioning out
    */
-  onExited: React.PropTypes.func
+  onExited: PropTypes.func
 };
 
 

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 import ownerDocument from './utils/ownerDocument';
 import getContainer from './utils/getContainer';
@@ -18,9 +19,9 @@ let Portal = React.createClass({
      * A Node, Component instance, or function that returns either. The `container` will have the Portal children
      * appended to it.
      */
-    container: React.PropTypes.oneOfType([
+    container: PropTypes.oneOfType([
       componentOrElement,
-      React.PropTypes.func
+      PropTypes.func
     ])
   },
 

--- a/src/Position.js
+++ b/src/Position.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 
 import calculatePosition from './utils/calculatePosition';
@@ -130,28 +131,28 @@ Position.propTypes = {
    * A node, element, or function that returns either. The child will be
    * be positioned next to the `target` specified.
    */
-  target: React.PropTypes.oneOfType([
-    componentOrElement, React.PropTypes.func
+  target: PropTypes.oneOfType([
+    componentOrElement, PropTypes.func
   ]),
 
   /**
    * "offsetParent" of the component
    */
-  container: React.PropTypes.oneOfType([
-    componentOrElement, React.PropTypes.func
+  container: PropTypes.oneOfType([
+    componentOrElement, PropTypes.func
   ]),
   /**
    * Minimum spacing in pixels between container border and component border
    */
-  containerPadding: React.PropTypes.number,
+  containerPadding: PropTypes.number,
   /**
    * How to position the component relative to the target
    */
-  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
   /**
    * Whether the position should be changed on each update
    */
-  shouldUpdatePosition: React.PropTypes.bool
+  shouldUpdatePosition: PropTypes.bool
 };
 
 Position.displayName = 'Position';

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -1,6 +1,7 @@
 import contains from 'dom-helpers/query/contains';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 import addEventListener from './utils/addEventListener';
 import ownerDocument from './utils/ownerDocument';
@@ -110,19 +111,19 @@ RootCloseWrapper.propTypes = {
   /**
    * Callback fired after click or mousedown. Also triggers when user hits `esc`.
    */
-  onRootClose: React.PropTypes.func,
+  onRootClose: PropTypes.func,
   /**
    * Children to render.
    */
-  children: React.PropTypes.element,
+  children: PropTypes.element,
   /**
    * Disable the the RootCloseWrapper, preventing it from triggering `onRootClose`.
    */
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Choose which document mouse event to bind to.
    */
-  event: React.PropTypes.oneOf(['click', 'mousedown'])
+  event: PropTypes.oneOf(['click', 'mousedown'])
 };
 
 RootCloseWrapper.defaultProps = {

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -3,6 +3,7 @@ import addEventListener from 'dom-helpers/events/on';
 import transitionInfo from 'dom-helpers/transition/properties';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 const transitionEndEvent = transitionInfo.end;
 
@@ -198,23 +199,23 @@ Transition.propTypes = {
   /**
    * Show the component; triggers the enter or exit animation
    */
-  in: React.PropTypes.bool,
+  in: PropTypes.bool,
 
   /**
    * Wait until the first "enter" transition to mount the component (add it to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount the component (remove it from the DOM) when it is not shown
    */
-  unmountOnExit: React.PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
 
   /**
    * Run the enter animation when the component mounts, if it is initially
    * shown
    */
-  transitionAppear: React.PropTypes.bool,
+  transitionAppear: PropTypes.bool,
 
   /**
    * A Timeout for the animation, in milliseconds, to ensure that a node doesn't
@@ -224,49 +225,49 @@ Transition.propTypes = {
    * By default this is set to a high number (5 seconds) as a failsafe. You should consider
    * setting this to the duration of your animation (or a bit above it).
    */
-  timeout: React.PropTypes.number,
+  timeout: PropTypes.number,
 
   /**
    * CSS class or classes applied when the component is exited
    */
-  exitedClassName: React.PropTypes.string,
+  exitedClassName: PropTypes.string,
   /**
    * CSS class or classes applied while the component is exiting
    */
-  exitingClassName: React.PropTypes.string,
+  exitingClassName: PropTypes.string,
   /**
    * CSS class or classes applied when the component is entered
    */
-  enteredClassName: React.PropTypes.string,
+  enteredClassName: PropTypes.string,
   /**
    * CSS class or classes applied while the component is entering
    */
-  enteringClassName: React.PropTypes.string,
+  enteringClassName: PropTypes.string,
 
   /**
    * Callback fired before the "entering" classes are applied
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
   /**
    * Callback fired after the "entering" classes are applied
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
   /**
    * Callback fired after the "enter" classes are applied
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
   /**
    * Callback fired before the "exiting" classes are applied
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
   /**
    * Callback fired after the "exiting" classes are applied
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
   /**
    * Callback fired after the "exited" classes are applied
    */
-  onExited: React.PropTypes.func
+  onExited: PropTypes.func
 };
 
 // Name the function so it is clearer in the documentation


### PR DESCRIPTION
`React.PropTypes` is deprecated, `prop-types` should be used instead.
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html
https://www.npmjs.com/package/prop-types