### PR TITLE
Remove duplicate import statements

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ReactDOM, { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/lib/Button';

--- a/src/Affix.js
+++ b/src/Affix.js
@@ -5,7 +5,6 @@ import getOffsetParent from 'dom-helpers/query/offsetParent';
 import getScrollTop from 'dom-helpers/query/scrollTop';
 import requestAnimationFrame from 'dom-helpers/util/requestAnimationFrame';
 import React from 'react';
-import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 import ownerDocument from './utils/ownerDocument';
 import getContainer from './utils/getContainer';

--- a/src/Position.js
+++ b/src/Position.js
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
 
 import calculatePosition from './utils/calculatePosition';

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -2,7 +2,6 @@ import contains from 'dom-helpers/query/contains';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 
 import addEventListener from './utils/addEventListener';
 import ownerDocument from './utils/ownerDocument';

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -4,7 +4,6 @@ import transitionInfo from 'dom-helpers/transition/properties';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 
 const transitionEndEvent = transitionInfo.end;
 


### PR DESCRIPTION
While upgrading for 15.5 I noticed this package had been recently updated but the latest build was failing.

Fixes duplicate `prop-types` import statements in multiple files.