### PR TITLE
Fix a typo on Position demo

### DIFF
--- a/examples/Position.js
+++ b/examples/Position.js
@@ -71,7 +71,7 @@ class PositionExample extends React.Component {
     return (
       <div className='overlay-example'>
         <Button bsStyle='primary' ref='target' onClick={this.toggle}>
-          I am an Position target
+          I am a Position target
         </Button>
         <p>
           keep clicking to see the placement change


### PR DESCRIPTION
"an position" should be "a position".