### PR TITLE
Target margin handling

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -33,7 +33,6 @@ class Overlay extends React.Component {
       , target
       , placement
       , insideMargin
-      , legacy
       , shouldUpdatePosition
       , rootClose
       , children
@@ -53,7 +52,7 @@ class Overlay extends React.Component {
     // Position is be inner-most because it adds inline styles into the child,
     // which the other wrappers don't forward correctly.
     child = (
-      <Position {...{container, containerPadding, target, placement, insideMargin, legacy, shouldUpdatePosition}}>
+      <Position {...{container, containerPadding, target, placement, insideMargin, shouldUpdatePosition}}>
         {child}
       </Position>
     );

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -32,6 +32,8 @@ class Overlay extends React.Component {
       , containerPadding
       , target
       , placement
+      , insideMargin
+      , legacy
       , shouldUpdatePosition
       , rootClose
       , children
@@ -51,7 +53,7 @@ class Overlay extends React.Component {
     // Position is be inner-most because it adds inline styles into the child,
     // which the other wrappers don't forward correctly.
     child = (
-      <Position {...{container, containerPadding, target, placement, shouldUpdatePosition}}>
+      <Position {...{container, containerPadding, target, placement, insideMargin, legacy, shouldUpdatePosition}}>
         {child}
       </Position>
     );

--- a/src/Position.js
+++ b/src/Position.js
@@ -121,7 +121,9 @@ class Position extends React.Component {
       overlay,
       target,
       container,
-      this.props.containerPadding
+      this.props.containerPadding,
+      this.props.insideMargin,
+      this.props.legacy
     ));
   }
 }
@@ -149,6 +151,10 @@ Position.propTypes = {
    * How to position the component relative to the target
    */
   placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  /**
+   * Whether to position the component inside the margins of the target
+   */
+  insideMargin: PropTypes.bool,
   /**
    * Whether the position should be changed on each update
    */

--- a/src/Position.js
+++ b/src/Position.js
@@ -122,8 +122,7 @@ class Position extends React.Component {
       target,
       container,
       this.props.containerPadding,
-      this.props.insideMargin,
-      this.props.legacy
+      this.props.insideMargin
     ));
   }
 }

--- a/src/utils/calculatePosition.js
+++ b/src/utils/calculatePosition.js
@@ -56,14 +56,12 @@ function getLeftDelta(left, overlayWidth, container, padding) {
 }
 
 export default function calculatePosition(
-  placement, overlayNode, target, container, padding, insideMargin, legacy
+  placement, overlayNode, target, container, padding, insideMargin
 ) {
   const childOffset = container.tagName === 'BODY' ?
     getOffset(target) : getPosition(target, container);
   const targetStyle = window.getComputedStyle(target)
-  if (legacy) {
-    // do nothing
-  } else if (insideMargin) {
+  if (insideMargin) {
     // apply margin offsets to top/left values for childOffset
     childOffset.top += parseInt(targetStyle.marginTop, 10) || 0;
     childOffset.left += parseInt(targetStyle.marginLeft, 10) || 0;

--- a/src/utils/calculatePosition.js
+++ b/src/utils/calculatePosition.js
@@ -56,10 +56,22 @@ function getLeftDelta(left, overlayWidth, container, padding) {
 }
 
 export default function calculatePosition(
-  placement, overlayNode, target, container, padding
+  placement, overlayNode, target, container, padding, insideMargin, legacy
 ) {
   const childOffset = container.tagName === 'BODY' ?
     getOffset(target) : getPosition(target, container);
+  const targetStyle = window.getComputedStyle(target)
+  if (legacy) {
+    // do nothing
+  } else if (insideMargin) {
+    // apply margin offsets to top/left values for childOffset
+    childOffset.top += parseInt(targetStyle.marginTop, 10) || 0;
+    childOffset.left += parseInt(targetStyle.marginLeft, 10) || 0;
+  } else {
+    // expand the bounds of our target to include its margins
+    childOffset.width += (parseInt(targetStyle.marginLeft, 10) + parseInt(targetStyle.marginRight, 10)) || 0;
+    childOffset.height +=  (parseInt(targetStyle.marginTop, 10) + parseInt(targetStyle.marginBottom, 10)) || 0;
+  }
 
   const { height: overlayHeight, width: overlayWidth } =
     getOffset(overlayNode);

--- a/src/utils/calculatePosition.js
+++ b/src/utils/calculatePosition.js
@@ -61,11 +61,10 @@ export default function calculatePosition(
   const childOffset = container.tagName === 'BODY' ?
     getOffset(target) : getPosition(target, container);
   const targetStyle = window.getComputedStyle(target)
-  if (insideMargin) {
+  if (!insideMargin) {
     // apply margin offsets to top/left values for childOffset
-    childOffset.top += parseInt(targetStyle.marginTop, 10) || 0;
-    childOffset.left += parseInt(targetStyle.marginLeft, 10) || 0;
-  } else {
+    childOffset.top -= parseInt(targetStyle.marginTop, 10) || 0;
+    childOffset.left -= parseInt(targetStyle.marginLeft, 10) || 0;
     // expand the bounds of our target to include its margins
     childOffset.width += (parseInt(targetStyle.marginLeft, 10) + parseInt(targetStyle.marginRight, 10)) || 0;
     childOffset.height +=  (parseInt(targetStyle.marginTop, 10) + parseInt(targetStyle.marginBottom, 10)) || 0;


### PR DESCRIPTION
Correctly handle the case where a target element has margins, with options to position the overlay either inside or outside the margins of the target.

Resolves #135 

![](https://i.imgur.com/7bDjckZ.gif)
