### PR TITLE
Modal container position should be fixed

### DIFF
--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -23,12 +23,13 @@ function findContainer(data, modal) {
 }
 
 function setContainerStyle(state, container) {
-  let style = { overflow: 'hidden' };
+  let style = { overflow: 'hidden', position: 'fixed' };
 
   // we are only interested in the actual `style` here
   // becasue we will override it
   state.style = {
     overflow: container.style.overflow,
+    position: container.style.position,
     paddingRight: container.style.paddingRight
   }
 

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -37,6 +37,7 @@ describe('ModalManager', ()=> {
       overflowing: false,
       style: {
         overflow: '',
+        position: '',
         paddingRight: ''
       }
     });
@@ -183,6 +184,16 @@ describe('ModalManager', ()=> {
       manager.add(modal, container);
 
       expect(container.style.overflow).to.equal('hidden');
+    });
+
+    it('should set container position to fixed ', ()=>{
+      let modal = new Modal({});
+
+      expect(container.style.position).to.equal('');
+
+      manager.add(modal, container);
+
+      expect(container.style.position).to.equal('fixed');
     });
 
     it('should respect handleContainerOverflow', ()=>{

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -72,10 +72,12 @@ describe('<Modal>', () => {
       let backdrop = modal.backdrop;
 
       expect($(instance).css('overflow')).to.equal('hidden');
+      expect($(instance).css('position')).to.equal('fixed');
 
       ReactTestUtils.Simulate.click(backdrop);
 
       expect($(instance).css('overflow')).to.not.equal('hidden');
+      expect($(instance).css('position')).to.not.equal('fixed');
 
       done();
     })


### PR DESCRIPTION
This CSS prevents the modal container from scrolling

### Steps to reproduce
1. Navigate to https://react-bootstrap.github.io/react-overlays/#modals on a mobile device
2. Open a modal
3. You should be able to scroll up/down