### PR TITLE
Use more robust method of getting dialog element

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -252,7 +252,7 @@ class Modal extends React.Component {
     } = this.props;
 
     let dialog = React.Children.only(children);
-    const filteredProps = this.omitProps(this.props, Modal.propTypes)
+    const filteredProps = this.omitProps(this.props, Modal.propTypes);
 
     const mountModal = show || (Transition && !this.state.exited);
     if (!mountModal) {
@@ -383,7 +383,7 @@ class Modal extends React.Component {
   }
 
   onPortalRendered = () => {
-    this.focus();
+    this.autoFocus();
 
     if (this.props.onShow) {
       this.props.onShow();
@@ -479,7 +479,7 @@ class Modal extends React.Component {
     }
   };
 
-  focus = () => {
+  autoFocus() {
     if (!this.props.autoFocus) {
       return;
     }
@@ -503,15 +503,15 @@ class Modal extends React.Component {
 
       dialogElement.focus();
     }
-  };
+  }
 
-  restoreLastFocus = () => {
+  restoreLastFocus() {
     // Support: <=IE11 doesn't support `focus()` on svg elements (RB: #917)
     if (this.lastFocus && this.lastFocus.focus) {
       this.lastFocus.focus();
       this.lastFocus = null;
     }
-  };
+  }
 
   enforceFocus = () => {
     if (
@@ -534,7 +534,7 @@ class Modal extends React.Component {
     return ReactDOM.findDOMNode(this.dialog);
   }
 
-  isTopModal = () => {
+  isTopModal() {
     return this.props.manager.isTopModal(this);
   }
 }

--- a/src/RefHolder.js
+++ b/src/RefHolder.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const propTypes = {
+  children: PropTypes.node,
+};
+
+/**
+ * Internal helper component to allow attaching a non-conflicting ref to a
+ * child element that may not accept refs.
+ */
+class RefHolder extends React.Component {
+  render() {
+    return this.props.children;
+  }
+}
+
+RefHolder.propTypes = propTypes;
+
+export default RefHolder;

--- a/test/LegacyPortalSpec.js
+++ b/test/LegacyPortalSpec.js
@@ -4,7 +4,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import Portal from '../src/LegacyPortal';
 
-describe('LegacyPortal', function () {
+describe('LegacyPortal', () => {
   let instance;
 
   class Overlay extends React.Component {
@@ -26,7 +26,7 @@ describe('LegacyPortal', function () {
     }
   }
 
-  it('Should render overlay into container (DOMNode)', function() {
+  it('should render overlay into container (DOMNode)', () => {
     let container = document.createElement('div');
 
     instance = ReactTestUtils.renderIntoDocument(
@@ -36,7 +36,7 @@ describe('LegacyPortal', function () {
     assert.equal(container.querySelectorAll('#test1').length, 1);
   });
 
-  it('Should render overlay into container (ReactComponent)', function() {
+  it('should render overlay into container (ReactComponent)', () => {
     class Container extends React.Component {
       render() {
         return <Overlay container={this} overlay={<div id="test1" />} />;
@@ -50,7 +50,7 @@ describe('LegacyPortal', function () {
     assert.equal(ReactDOM.findDOMNode(instance).querySelectorAll('#test1').length, 1);
   });
 
-  it('Should not render a null overlay', function() {
+  it('should not render a null overlay', () => {
     class Container extends React.Component {
       render() {
         return (
@@ -71,7 +71,7 @@ describe('LegacyPortal', function () {
   });
 
 
-  it('Should change container on prop change', function() {
+  it('should change container on prop change', () => {
     class ContainerTest extends React.Component {
       state = {};
       render() {
@@ -103,7 +103,7 @@ describe('LegacyPortal', function () {
     );
   });
 
-  it('Should unmount when parent unmounts', function() {
+  it('should unmount when parent unmounts', () => {
     class Parent extends React.Component {
       state = {show: true};
       render() {
@@ -134,5 +134,4 @@ describe('LegacyPortal', function () {
 
     instance.setState({show: false});
   });
-
 });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -419,7 +419,6 @@ describe('<Modal>', () => {
         </Modal>
         , focusableContainer);
 
-
       focusableContainer.focus();
 
       document.activeElement.className.should.contain('modal');

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -12,16 +12,15 @@ import { render, shouldWarn } from './helpers';
 
 const $ = componentOrNode => jQuery(ReactDOM.findDOMNode(componentOrNode));
 
-
-describe('Modal', function () {
+describe('<Modal>', () => {
   let mountPoint;
 
-  beforeEach(()=>{
+  beforeEach(() => {
     mountPoint = document.createElement('div');
     document.body.appendChild(mountPoint);
   });
 
-  afterEach(function () {
+  afterEach(() => {
     const unmounted = ReactDOM.unmountComponentAtNode(mountPoint);
     if (unmounted) {
       document.body.removeChild(mountPoint);
@@ -29,17 +28,19 @@ describe('Modal', function () {
     mountPoint.remove()
   });
 
-  it('Should render the modal content', function() {
+  it('should render the modal content', () => {
     let instance = render(
       <Modal show>
         <strong>Message</strong>
       </Modal>
     , mountPoint);
 
-    expect(instance.modalNode.querySelectorAll('strong').length).to.equal(1);
+    expect(
+      instance.modalNode.querySelectorAll('strong'),
+    ).to.have.lengthOf(1);
   });
 
-  it('Should disable scrolling on the modal container while open', (done) => {
+  it('should disable scrolling on the modal container while open', (done) => {
     class Container extends React.Component {
       state = {
         modalOpen: true,
@@ -80,7 +81,7 @@ describe('Modal', function () {
     })
   });
 
-  it('Should add and remove container classes', function() {
+  it('should add and remove container classes', () => {
     class Container extends React.Component {
       state = { modalOpen: true };
       handleCloseModal = () => {
@@ -113,7 +114,7 @@ describe('Modal', function () {
     expect($(instance).hasClass('test test2')).to.be.false;
   });
 
-  it('Should fire backdrop click callback', function () {
+  it('should fire backdrop click callback', () => {
     let onClickSpy = sinon.spy();
     let instance = render(
       <Modal show onBackdropClick={onClickSpy}>
@@ -128,8 +129,8 @@ describe('Modal', function () {
     expect(onClickSpy).to.have.been.calledOnce;
   });
 
-  it('Should close the modal when the backdrop is clicked', function (done) {
-    let doneOp = function () { done(); };
+  it('should close the modal when the backdrop is clicked', (done) => {
+    let doneOp = () => { done(); };
     let instance = render(
       <Modal show onHide={doneOp}>
         <strong>Message</strong>
@@ -141,7 +142,7 @@ describe('Modal', function () {
     ReactTestUtils.Simulate.click(backdrop);
   });
 
-  it('Should not close the modal when the "static" backdrop is clicked', function () {
+  it('should not close the modal when the "static" backdrop is clicked', () => {
     let onHideSpy = sinon.spy();
     let instance = render(
       <Modal show onHide={onHideSpy} backdrop='static'>
@@ -156,8 +157,8 @@ describe('Modal', function () {
     expect(onHideSpy).to.not.have.been.called;
   });
 
-  it('Should close the modal when the esc key is pressed', function (done) {
-    let doneOp = function () { done(); };
+  it('should close the modal when the esc key is pressed', (done) => {
+    let doneOp = () => { done(); };
     let instance = render(
       <Modal show onHide={doneOp}>
         <strong>Message</strong>
@@ -170,7 +171,7 @@ describe('Modal', function () {
   });
 
 
-  it('Should set backdrop Style', function () {
+  it('should set backdrop Style', () => {
     let instance = render(
       <Modal show className='mymodal' backdrop backdropStyle={{ borderWidth: '3px' }}>
         <strong>Message</strong>
@@ -182,8 +183,8 @@ describe('Modal', function () {
       backdrop.style.borderWidth).to.equal('3px');
   });
 
-  it('Should throw with multiple children', function () {
-    expect(function(){
+  it('should throw with multiple children', () => {
+    expect(() => {
       ReactDOMServer.renderToString(
         <Modal show>
           <strong>Message</strong>
@@ -192,7 +193,7 @@ describe('Modal', function () {
     }).to.throw(/React.Children.only expected to receive a single React element child./);
   });
 
-  it('Should add role to child', function () {
+  it('should add role to child', () => {
     let instance = render(
       <Modal show>
         <strong>Message</strong>
@@ -203,7 +204,7 @@ describe('Modal', function () {
       instance.getDialogElement().getAttribute('role')).to.equal('document');
   });
 
-  it('Should not add role when SET', function () {
+  it('should not add role when SET', () => {
     let instance = render(
       <Modal show>
         <strong role='group'>Message</strong>
@@ -214,7 +215,7 @@ describe('Modal', function () {
       instance.getDialogElement().getAttribute('role')).to.equal('group');
   });
 
-  it('Should not add role when explicitly `null`', function () {
+  it('should not add role when explicitly `null`', () => {
     let instance = render(
       <Modal show>
         <strong role={null}>Message</strong>
@@ -225,7 +226,7 @@ describe('Modal', function () {
       instance.getDialogElement().getAttribute('role')).to.equal(null);
   });
 
-  it('Should unbind listeners when unmounted', function() {
+  it('should unbind listeners when unmounted', () => {
     render(
         <div>
           <Modal show containerClassName='modal-open'>
@@ -241,7 +242,7 @@ describe('Modal', function () {
     assert.ok(!$(document.body).hasClass('modal-open'));
   });
 
-  it('Should pass transition callbacks to Transition', function (done) {
+  it('should pass transition callbacks to Transition', (done) => {
     let count = 0;
     let increment = ()=> count++;
 
@@ -267,7 +268,7 @@ describe('Modal', function () {
       , mountPoint);
   });
 
-  it('Should fire show callback on mount', function () {
+  it('should fire show callback on mount', () => {
     let onShowSpy = sinon.spy();
     render(
       <Modal show onShow={onShowSpy}>
@@ -278,7 +279,7 @@ describe('Modal', function () {
     expect(onShowSpy).to.have.been.calledOnce;
   });
 
-  it('Should fire show callback on update', function () {
+  it('should fire show callback on update', () => {
     let onShowSpy = sinon.spy();
     let instance = render(
       <Modal onShow={onShowSpy}>
@@ -291,7 +292,7 @@ describe('Modal', function () {
     expect(onShowSpy).to.have.been.calledOnce;
   });
 
-  it('Should fire onEscapeKeyDown callback on escape close', function () {
+  it('should fire onEscapeKeyDown callback on escape close', () => {
     let onEscapeSpy = sinon.spy();
     let instance = render(
       <Modal onEscapeKeyDown={onEscapeSpy}>
@@ -306,7 +307,7 @@ describe('Modal', function () {
     expect(onEscapeSpy).to.have.been.calledOnce;
   });
 
-  it('Should fire onEscapeKeyUp callback on escape close keyDown', function () {
+  it('should fire onEscapeKeyUp callback on escape close keyDown', () => {
     shouldWarn('Please use onEscapeKeyDown instead for consistency');
 
     let onEscapeSpy = sinon.spy();
@@ -323,18 +324,19 @@ describe('Modal', function () {
     expect(onEscapeSpy).to.have.been.calledOnce;
   });
 
-  it('Should accept role on the Modal', function () {
+  it('should accept role on the Modal', () => {
     let instance = render(
       <Modal role="alertdialog" show>
         <strong>Message</strong>
       </Modal>
     , mountPoint);
 
-    let attr = instance.modalNode.attributes.getNamedItem('role').value;
-    expect(attr).to.equal('alertdialog');
+    expect(
+      instance.modalNode.attributes.getNamedItem('role').value,
+    ).to.equal('alertdialog');
   });
 
-  it('Should accept the `aria-describedby` property on the Modal', function () {
+  it('should accept the `aria-describedby` property on the Modal', () => {
 
     let instance = render(
       <Modal aria-describedby="modal-description" show>
@@ -342,14 +344,15 @@ describe('Modal', function () {
       </Modal>
     , mountPoint);
 
-    let attr = instance.modalNode.attributes.getNamedItem('aria-describedby').value;
-    expect(attr).to.equal('modal-description');
+    expect(
+      instance.modalNode.attributes.getNamedItem('aria-describedby').value,
+    ).to.equal('modal-description');
   });
 
-  describe('Focused state', function () {
+  describe('Focused state', () => {
     let focusableContainer = null;
 
-    beforeEach(()=>{
+    beforeEach(() => {
       focusableContainer = document.createElement('div');
       focusableContainer.tabIndex = 0;
       focusableContainer.className = 'focus-container';
@@ -357,12 +360,12 @@ describe('Modal', function () {
       focusableContainer.focus();
     });
 
-    afterEach(function () {
+    afterEach(() => {
       ReactDOM.unmountComponentAtNode(focusableContainer);
       document.body.removeChild(focusableContainer);
     });
 
-    it('Should focus on the Modal when it is opened', function () {
+    it('should focus on the Modal when it is opened', () => {
       expect(document.activeElement).to.equal(focusableContainer);
 
       let instance = render(
@@ -379,7 +382,7 @@ describe('Modal', function () {
     });
 
 
-    it('Should not focus on the Modal when autoFocus is false', function () {
+    it('should not focus on the Modal when autoFocus is false', () => {
       render(
         <Modal show autoFocus={false}>
           <strong>Message</strong>
@@ -389,8 +392,7 @@ describe('Modal', function () {
       expect(document.activeElement).to.equal(focusableContainer);
     });
 
-    it('Should not focus Modal when child has focus', function () {
-
+    it('should not focus Modal when child has focus', () => {
       expect(document.activeElement).to.equal(focusableContainer);
 
       render(
@@ -406,7 +408,7 @@ describe('Modal', function () {
       expect(document.activeElement).to.equal(input);
     });
 
-    it('Should return focus to the modal', () => {
+    it('should return focus to the modal', () => {
       expect(document.activeElement).to.equal(focusableContainer);
 
       render(
@@ -423,7 +425,7 @@ describe('Modal', function () {
       document.activeElement.className.should.contain('modal');
     });
 
-    it('Should warn if the modal content is not focusable', function () {
+    it('should warn if the modal content is not focusable', () => {
       shouldWarn('The modal content node does not accept focus');
 
       const Dialog = () => <div />;
@@ -434,6 +436,15 @@ describe('Modal', function () {
         </Modal>
         , focusableContainer);
     });
-  });
 
+    it('should not attempt to focus nonexistent children', () => {
+      const Dialog = () => null;
+
+      render(
+        <Modal show>
+          <Dialog />
+        </Modal>
+        , focusableContainer);
+    })
+  });
 });


### PR DESCRIPTION
Note base branch.

Mostly fixes https://github.com/react-bootstrap/react-bootstrap/issues/2600
Ref https://github.com/react-bootstrap/react-overlays/pull/208/files#r142582319

Sorry for the random formatting changes on the tests. Got carried away.

Perhaps we should still check for `.hasAttribute` on `dialogElement`, though – in the case where it's e.g. a text node, the dialog element will just be a string and thus won't have that method.