### PR TITLE
Drop busted getOverlayDOMNode

### DIFF
--- a/src/LegacyPortal.js
+++ b/src/LegacyPortal.js
@@ -12,7 +12,6 @@ import ownerDocument from './utils/ownerDocument';
  * The children of `<Portal/>` component will be appended to the `container` specified.
  */
 class Portal extends React.Component {
-
   static displayName = 'Portal';
 
   static propTypes = {
@@ -58,7 +57,7 @@ class Portal extends React.Component {
       this._portalContainerNode = getContainer(this.props.container, ownerDocument(this).body);
       this._portalContainerNode.appendChild(this._overlayTarget);
     }
-  }
+  };
 
   _unmountOverlayTarget = () => {
     if (this._overlayTarget) {
@@ -66,7 +65,7 @@ class Portal extends React.Component {
       this._overlayTarget = null;
     }
     this._portalContainerNode = null;
-  }
+  };
 
   _renderOverlay = () => {
     let overlay = !this.props.children
@@ -90,14 +89,14 @@ class Portal extends React.Component {
       this._unrenderOverlay();
       this._unmountOverlayTarget();
     }
-  }
+  };
 
   _unrenderOverlay = () => {
     if (this._overlayTarget) {
       ReactDOM.unmountComponentAtNode(this._overlayTarget);
       this._overlayInstance = null;
     }
-  }
+  };
 
   render() {
     return null;
@@ -105,20 +104,7 @@ class Portal extends React.Component {
 
   getMountNode = () => {
     return this._overlayTarget;
-  }
-
-  getOverlayDOMNode = () => {
-    if (!this._isMounted) {
-      throw new Error('getOverlayDOMNode(): A component must be mounted to have a DOM node.');
-    }
-
-    if (this._overlayInstance) {
-      return ReactDOM.findDOMNode(this._overlayInstance);
-    }
-
-    return null;
-  }
-
+  };
 }
 
 export default Portal;

--- a/src/Portal.js
+++ b/src/Portal.js
@@ -14,7 +14,6 @@ import LegacyPortal from './LegacyPortal'
  * The children of `<Portal/>` component will be appended to the `container` specified.
  */
 class Portal extends React.Component {
-
   static displayName = 'Portal';
 
   static propTypes = {
@@ -31,8 +30,7 @@ class Portal extends React.Component {
   };
 
   componentDidMount() {
-    this._isMounted = true;
-    this.setContainer()
+    this.setContainer();
     this.forceUpdate(this.props.onRendered)
   }
 
@@ -43,13 +41,14 @@ class Portal extends React.Component {
   }
 
   componentWillUnmount() {
-    this._isMounted = false;
     this._portalContainerNode = null;
   }
 
   setContainer = (props = this.props) => {
-    this._portalContainerNode = getContainer(props.container, ownerDocument(this).body);
-  }
+    this._portalContainerNode = getContainer(
+      props.container, ownerDocument(this).body,
+    );
+  };
 
   render() {
     return this.props.children && this._portalContainerNode ?
@@ -59,19 +58,7 @@ class Portal extends React.Component {
 
   getMountNode = () => {
     return this._portalContainerNode;
-  }
-
-  getOverlayDOMNode = () => {
-    if (!this._isMounted) {
-      throw new Error('getOverlayDOMNode(): A component must be mounted to have a DOM node.');
-    }
-
-    if (this._overlayInstance) {
-      return ReactDOM.findDOMNode(this._overlayInstance);
-    }
-
-    return null;
-  }
+  };
 }
 
 export default ReactDOM.createPortal ? Portal : LegacyPortal;

--- a/test/LegacyPortalSpec.js
+++ b/test/LegacyPortalSpec.js
@@ -5,8 +5,6 @@ import ReactTestUtils from 'react-dom/test-utils';
 import Portal from '../src/LegacyPortal';
 
 describe('LegacyPortal', () => {
-  let instance;
-
   class Overlay extends React.Component {
     render() {
       return (
@@ -20,16 +18,12 @@ describe('LegacyPortal', () => {
         </div>
       );
     }
-
-    getOverlayDOMNode = () => {
-      return this.portal.getOverlayDOMNode();
-    }
   }
 
   it('should render overlay into container (DOMNode)', () => {
-    let container = document.createElement('div');
+    const container = document.createElement('div');
 
-    instance = ReactTestUtils.renderIntoDocument(
+    ReactTestUtils.renderIntoDocument(
       <Overlay container={container} overlay={<div id="test1" />} />
     );
 
@@ -43,11 +37,13 @@ describe('LegacyPortal', () => {
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Container />
     );
 
-    assert.equal(ReactDOM.findDOMNode(instance).querySelectorAll('#test1').length, 1);
+    expect(
+      ReactDOM.findDOMNode(instance).querySelectorAll('#test1')
+    ).to.have.lengthOf(1)
   });
 
   it('should not render a null overlay', () => {
@@ -63,11 +59,11 @@ describe('LegacyPortal', () => {
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Container />
     );
 
-    assert.equal(instance.overlay.getOverlayDOMNode(), null);
+    expect(ReactDOM.findDOMNode(instance).childNodes).to.be.empty;
   });
 
 
@@ -90,7 +86,7 @@ describe('LegacyPortal', () => {
       }
     }
 
-    let overlayInstance = ReactTestUtils.renderIntoDocument(
+    const overlayInstance = ReactTestUtils.renderIntoDocument(
       <ContainerTest overlay={<div id="test1" />} />
     );
 
@@ -128,7 +124,7 @@ describe('LegacyPortal', () => {
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Parent />
     );
 

--- a/test/PortalSpec.js
+++ b/test/PortalSpec.js
@@ -4,9 +4,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 
 import Portal from '../src/Portal';
 
-describe('Portal', function () {
-  let instance;
-
+describe('Portal', () => {
   class Overlay extends React.Component {
     render() {
       return (
@@ -20,37 +18,35 @@ describe('Portal', function () {
         </div>
       );
     }
-
-    getOverlayDOMNode = () => {
-      return this.portal.getOverlayDOMNode();
-    }
   }
 
-  it('Should render overlay into container (DOMNode)', function() {
-    let container = document.createElement('div');
+  it('should render overlay into container (DOMNode)', () => {
+    const container = document.createElement('div');
 
-    instance = ReactTestUtils.renderIntoDocument(
+    ReactTestUtils.renderIntoDocument(
       <Overlay container={container} overlay={<div id="test1" />} />
     );
 
     assert.equal(container.querySelectorAll('#test1').length, 1);
   });
 
-  it('Should render overlay into container (ReactComponent)', function() {
+  it('should render overlay into container (ReactComponent)', () => {
     class Container extends React.Component {
       render() {
         return <Overlay container={this} overlay={<div id="test1" />} />;
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Container />
     );
 
-    assert.equal(ReactDOM.findDOMNode(instance).querySelectorAll('#test1').length, 1);
+    expect(
+      ReactDOM.findDOMNode(instance).querySelectorAll('#test1')
+    ).to.have.lengthOf(1)
   });
 
-  it('Should not render a null overlay', function() {
+  it('should not fail to render a null overlay', () => {
     class Container extends React.Component {
       render() {
         return (
@@ -63,15 +59,14 @@ describe('Portal', function () {
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Container />
     );
 
-    assert.equal(instance.overlay.getOverlayDOMNode(), null);
+    expect(ReactDOM.findDOMNode(instance).childNodes).to.be.empty;
   });
 
-
-  it('Should change container on prop change', function() {
+  it('should change container on prop change', () => {
     class ContainerTest extends React.Component {
       state = {};
       render() {
@@ -90,12 +85,12 @@ describe('Portal', function () {
       }
     }
 
-    let overlayInstance = ReactTestUtils.renderIntoDocument(
-      <ContainerTest overlay={<div id="test1" />} />
+    const overlayInstance = ReactTestUtils.renderIntoDocument(
+      <ContainerTest overlay={<div id="test1" />} />,
     );
 
     assert.equal(overlayInstance.portal._portalContainerNode.nodeName, 'BODY');
-    overlayInstance.setState({container: overlayInstance.container})
+    overlayInstance.setState({container: overlayInstance.container});
     assert.equal(overlayInstance.portal._portalContainerNode.nodeName, 'DIV');
 
     ReactDOM.unmountComponentAtNode(
@@ -103,7 +98,7 @@ describe('Portal', function () {
     );
   });
 
-  it('Should unmount when parent unmounts', function() {
+  it('should unmount when parent unmounts', () => {
     class Parent extends React.Component {
       state = {show: true};
       render() {
@@ -128,7 +123,7 @@ describe('Portal', function () {
       }
     }
 
-    instance = ReactTestUtils.renderIntoDocument(
+    const instance = ReactTestUtils.renderIntoDocument(
       <Parent />
     );
 


### PR DESCRIPTION
It actually doesn't even do anything on the non-legacy portal. Plus it's broken on the legacy portal half the time anyway. Since we already broke it, and we don't document it, I'm going to say this was some internal test-only thing, and it's not semver-breaking to just remove it entirely.