### PR TITLE
Add support for `offsetBottom` in `AutoAffix`  [fixes #186]

### DIFF
--- a/examples/Affix.js
+++ b/examples/Affix.js
@@ -1,14 +1,32 @@
 import React from 'react';
 import AutoAffix from 'react-overlays/lib/AutoAffix';
 
+const OFFSET = 100
+
 class AffixExample extends React.Component {
+  state = {
+    offsetting: false
+  };
+
+  handleToggleOffset = () => {
+    this.setState({offsetting: !this.state.offsetting});
+  }
+
   render() {
+    const { offsetting } = this.state
+    const offsetBottom = offsetting ? OFFSET : null;
     return (
       <div className='affix-example'>
-        <AutoAffix viewportOffsetTop={15} container={this}>
+        <AutoAffix viewportOffsetTop={15} container={this} offsetBottom={offsetBottom}>
           <div className='panel panel-default'>
             <div className='panel-body'>
               I am an affixed element
+            </div>
+
+            <div className="panel-footer">
+              <button className="btn btn-default" onClick={this.handleToggleOffset}>
+                <code>offsetBottom: {offsetBottom || 'null'}</code> {offsetting ? 'Remove' : 'Add'}
+              </button>
             </div>
           </div>
         </AutoAffix>

--- a/examples/styles.less
+++ b/examples/styles.less
@@ -193,4 +193,5 @@ h4 a:focus .anchor-icon {
 
 .affix-example {
   height: 500px;
+  border: solid 1px;
 }

--- a/src/AutoAffix.js
+++ b/src/AutoAffix.js
@@ -33,7 +33,8 @@ const propTypes = {
 // auto-calculated offsets can apply.
 const defaultProps = {
   viewportOffsetTop: 0,
-  autoWidth: true
+  autoWidth: true,
+  offsetBottom: 0
 };
 
 /**
@@ -121,7 +122,7 @@ class AutoAffix extends React.Component {
     if (container) {
       const documentHeight = getDocumentHeight(ownerDocument(this));
       const {top, height} = getOffset(container);
-      offsetBottom = documentHeight - top - height;
+      offsetBottom = documentHeight - top - height + this.props.offsetBottom;
     } else {
       offsetBottom = null;
     }

--- a/test/AutoAffixSpec.js
+++ b/test/AutoAffixSpec.js
@@ -38,7 +38,7 @@ describe('<AutoAffix>', () => {
         <div style={{width: 200, height: 10000}}>
           <div style={{height: 100}} />
 
-          <AutoAffix container={this} viewportOffsetTop={0}>
+          <AutoAffix container={this} viewportOffsetTop={0} {...this.props}>
             <Content style={{height: 100}} />
           </AutoAffix>
         </div>
@@ -59,9 +59,10 @@ describe('<AutoAffix>', () => {
 
   describe('affix behavior', () => {
     let node;
+    let container
 
     beforeEach(() => {
-      const container = render((
+      container = render((
         <Container>
           <Fixture />
         </Container>
@@ -101,6 +102,31 @@ describe('<AutoAffix>', () => {
         expect(node.style.top).to.equal('9900px');
         expect(node.style.width).to.equal('200px');
         done();
+      });
+    });
+
+    describe('offsetBottom', () => {
+      beforeEach(() => {
+        container = render((
+          <Container>
+            <Fixture offsetBottom={100}/>
+          </Container>
+        ), mountPoint);
+
+        node = ReactDOM.findDOMNode(ReactTestUtils.findRenderedComponentWithType(
+          container, Content
+        ));
+      });
+
+      it('should render correctly at bottom', (done) => {
+        window.scrollTo(0, 9810);
+
+        requestAnimationFrame(() => {
+          expect(node.style.position).to.equal('absolute');
+          expect(node.style.top).to.equal('9800px');
+          expect(node.style.width).to.equal('200px');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes #186 

Adds support of `offsetBottom` property on `AutoAffix`. 

Setting `offsetBottom` to a non-zero integer will add (or remove) padding to the bottom of the container.

![offset-bottom-fix](https://user-images.githubusercontent.com/464764/33164305-fe78b290-cfe6-11e7-8155-835ab2677d78.gif)
