### PR TITLE
Adds rootCloseEvent prop to Overlay to pass down to RootCloseWrapper

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -80,7 +80,10 @@ class Overlay extends React.Component {
     // This goes after everything else because it adds a wrapping div.
     if (rootClose) {
       child = (
-        <RootCloseWrapper onRootClose={props.onHide}>
+        <RootCloseWrapper
+          onRootClose={props.onHide}
+          event={props.rootCloseEvent}
+        >
           {child}
         </RootCloseWrapper>
       );
@@ -115,6 +118,11 @@ Overlay.propTypes = {
    * Specify whether the overlay should trigger `onHide` when the user clicks outside the overlay
    */
   rootClose: PropTypes.bool,
+
+  /**
+   * Specify event for toggling overlay
+   */
+  rootCloseEvent: RootCloseWrapper.propTypes.event,
 
   /**
    * A Callback fired by the Overlay when it wishes to be hidden.

--- a/test/OverlaySpec.js
+++ b/test/OverlaySpec.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import Overlay from '../src/Overlay';
+import RootCloseWrapper from '../src/RootCloseWrapper';
+
+import { render } from './helpers';
+
+function Tooltip(props) {
+  return <div>{props.children}</div>;
+}
+
+describe('Overlay', () => {
+  let mountPoint;
+  let trigger;
+
+  beforeEach(() => {
+    mountPoint = document.createElement('div');
+    trigger = document.createElement('div');
+
+    document.body.appendChild(mountPoint);
+    document.body.appendChild(trigger);
+  });
+
+  afterEach(() => {
+    ReactDOM.unmountComponentAtNode(mountPoint);
+    document.body.removeChild(mountPoint);
+    document.body.removeChild(trigger);
+  });
+
+  describe('is wrapped with RootCloseWrapper if rootClose prop passed', () => {
+    const props = {
+      rootClose: true,
+      show: true,
+      target: trigger,
+      onHide: () => {}
+    };
+
+    let instance;
+
+    beforeEach(() => {
+      instance = render(
+        <Overlay { ...props }>
+          <Tooltip>hello there</Tooltip>
+        </Overlay>
+      , mountPoint);
+    });
+
+    it('renders RootCloseWrapper', () => {
+      const wrapper = ReactTestUtils.findRenderedComponentWithType(
+        instance, RootCloseWrapper
+      );
+
+      expect(wrapper).to.exist;
+      expect(wrapper.props.onRootClose).to.equal(props.onHide);
+    });
+
+    it('passes down the rootCloseEvent', () => {
+      instance = instance.renderWithProps({ ...props, rootCloseEvent: 'mousedown' });
+
+      const wrapper = ReactTestUtils.findRenderedComponentWithType(
+        instance, RootCloseWrapper
+      );
+
+      expect(wrapper.props.event).to.equal('mousedown');
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes https://github.com/react-bootstrap/react-overlays/issues/153 and supersedes https://github.com/react-bootstrap/react-overlays/pull/156.