### PR TITLE
Integration react-overlays with react-motion

### DIFF
--- a/examples/App.js
+++ b/examples/App.js
@@ -5,6 +5,7 @@ import ReactDOM, { findDOMNode } from 'react-dom';
 import Button from 'react-bootstrap/lib/Button';
 import Transition, { ENTERED, ENTERING }
   from 'react-transition-group/Transition';
+  import {TransitionMotion, spring, presets } from 'react-motion';
 
 import PropTable from './PropTable';
 
@@ -15,6 +16,7 @@ import PortalSource from '../webpack/example-loader!./Portal';
 import PositionSource from '../webpack/example-loader!./Position';
 import RootCloseWrapperSource from '../webpack/example-loader!./RootCloseWrapper';
 import TransitionSource from '../webpack/example-loader!./Transition';
+import TransitionModelSource from '../webpack/example-loader!./TransitionModel';
 
 import AffixMetadata from 'component-metadata-loader?pitch!react-overlays/Affix';
 import AutoAffixMetadata from 'component-metadata-loader?pitch!react-overlays/AutoAffix';
@@ -32,7 +34,7 @@ import injectCss from './injectCss';
 
 const scope = {
   React, ReactDOM, findDOMNode, Button, injectCss, ...ReactOverlays, getOffset,
-  Transition, ENTERED, ENTERING,
+  Transition, ENTERED, ENTERING, TransitionMotion, spring, presets,
 };
 
 class Anchor extends React.Component {
@@ -90,6 +92,7 @@ class Example extends React.Component {
             <li><a href='#affixes'>Affixes</a></li>
             <li><a href='#root-close-wrapper'>RootCloseWrapper</a></li>
             <li><a href='#transitions'>Transitions</a></li>
+            <li><a href='#transitions-motion'>Transitions Using Motion</a></li>
           </ul>
         </article>
         <main className='col-md-10'>
@@ -180,6 +183,23 @@ class Example extends React.Component {
             </p>
 
             <ExampleEditor codeText={TransitionSource} />
+          </section>
+          <section >
+            <h2 className='page-header'>
+              <Anchor id='transitions-motion'>Transition Model using React Motion</Anchor>
+            </h2>
+            <p>
+              Animation of components is handled by <code>transition</code> props.
+              If a component accepts a <code>transition</code> prop you can provide
+              a <a href="https://github.com/reactjs/react-transition-group">react-transition-group@2.0.0</a> compatible
+              <code>Transition Motion</code> component and it will work.
+            </p>
+
+            <p>
+              Feel free to use <code>CSSTransition</code> specifically, or roll your own like the below example.
+            </p>
+
+            <ExampleEditor codeText={TransitionModelSource} />
           </section>
         </main>
       </div>

--- a/examples/TransitionModel.js
+++ b/examples/TransitionModel.js
@@ -1,0 +1,154 @@
+import React from "react";
+import Button from "react-bootstrap/lib/Button";
+import ModalMotion from "react-overlays/lib/ModalMotion";
+import {TransitionMotion, spring, presets } from "react-motion";
+import injectCss from "./injectCss";
+
+const FADE_DURATION = 200;
+
+injectCss(`
+  .fade {
+    opacity: 0;
+    transition: opacity ${FADE_DURATION}ms linear;
+  }
+
+  .in {
+    opacity: 1;
+  }
+
+  .transition-example-modal {
+    position: fixed;
+    z-index: 1040;
+    top: 0; bottom: 0; left: 0; right: 0;
+  }
+
+  .transition-example-backdrop {
+    position: fixed;
+    top: 0; bottom: 0; left: 0; right: 0;
+    background-color: #000;
+  }
+
+
+  .transition-example-dialog {
+    position: absolute;
+    width: 400;
+    top: 50%; left: 50%;
+    transform: translate(-50%, -50%);
+    border: 1px solid #e5e5e5;
+    background-color: white;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, .5);
+    padding: 20px;
+  }
+`);
+
+
+const dialogMotion = ({ children, ...props }) => {
+  let styles = {};
+  let allStyles = [];
+  if (props.in) {
+    styles.opacity =  spring(1, presets.gentle);
+  } else {
+    styles.opacity = spring(0, presets.gentle);
+  }
+  allStyles = [{ key: 'one', style: styles }];
+  return (
+    <TransitionMotion
+     defaultStyles={[
+        {
+          key: 'one',
+          style: {
+            opacity: 1
+          }
+        }
+      ]} 
+      styles={allStyles}
+    >
+      {styles => (
+        <div>
+          {styles.map(({ key, style }) =>
+            React.cloneElement(children, {
+              ...style,
+              key: { key }
+            })
+          )}
+        </div>
+      )}
+    </TransitionMotion>
+  );
+};
+
+
+const dialogBackgroundMotion = ({ children, ...props }) => {
+  let styles = {};
+  let allStyles = [];
+  if (props.in) {
+    styles.opacity = spring(0.5, presets.gentle);
+  } else {
+    styles.opacity = spring(0, presets.gentle);
+  }
+  allStyles = [{ key: 'two', style: styles }];
+  return (
+    <TransitionMotion
+      defaultStyles={[
+        {
+          key: 'two',
+          style: {
+            opacity: 0
+        
+          }
+        }
+      ]}
+      styles={allStyles}
+    >
+      {styles => (
+        <div>
+          {styles.map(({ key, style }) =>
+            React.cloneElement(children, {
+              style: {...style},
+              key: { key }
+            })
+          )}
+        </div>
+      )}
+    </TransitionMotion>
+  );
+};
+
+class TransitionExample extends React.Component {
+  state = { showModal: false };
+
+  toggle = () => {
+    return this.setState({ showModal: !this.state.showModal });
+  };
+
+  render() {
+    return (
+      <div className="transition-example">
+        <Button bsStyle="primary" onClick={this.toggle}>
+          Show Animated Modal
+        </Button>
+
+        <ModalMotion
+          transition={dialogMotion}
+          backdropTransition={dialogBackgroundMotion}
+          className="transition-example-modal"
+          backdropClassName="transition-example-backdrop"
+          show={this.state.showModal}
+          onHide={this.toggle}
+        >
+          <div className="transition-example-dialog">
+            <h4 id="modal-label">I'm fading in!</h4>
+            <p>
+              Anim pariatur cliche reprehenderit, enim eiusmod high life
+              accusamus terry richardson ad squid. Nihil anim keffiyeh
+              helvetica, craft beer labore wes anderson cred nesciunt sapiente
+              ea proident.
+            </p>
+          </div>
+        </ModalMotion>
+      </div>
+    );
+  }
+}
+
+export default TransitionExample;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dom-helpers": "^3.2.1",
     "prop-types": "^15.5.10",
     "prop-types-extra": "^1.0.1",
+    "react-motion": "^0.5.2",
     "react-transition-group": "^2.2.0",
     "warning": "^3.0.0"
   },

--- a/src/ModalMotion.js
+++ b/src/ModalMotion.js
@@ -1,0 +1,537 @@
+/* eslint-disable react/prop-types */
+
+import activeElement from 'dom-helpers/activeElement';
+import contains from 'dom-helpers/query/contains';
+import canUseDom from 'dom-helpers/util/inDOM';
+import PropTypes from 'prop-types';
+import componentOrElement from 'prop-types-extra/lib/componentOrElement';
+import deprecated from 'prop-types-extra/lib/deprecated';
+import elementType from 'prop-types-extra/lib/elementType';
+import React, { cloneElement } from 'react';
+import ReactDOM from 'react-dom';
+import warning from 'warning';
+
+import ModalManager from './modalManager';
+import Portal from './Portal';
+import RefHolder from './RefHolder';
+
+import addEventListener from './utils/addEventListener';
+import addFocusListener from './utils/addFocusListener';
+import getContainer from './utils/getContainer';
+import ownerDocument from './utils/ownerDocument';
+
+let modalManager = new ModalManager();
+
+/**
+ * Love them or hate them, `<Modal/>` provides a solid foundation for creating dialogs, lightboxes, or whatever else.
+ * The Modal component renders its `children` node in front of a backdrop component.
+ *
+ * The Modal offers a few helpful features over using just a `<Portal/>` component and some styles:
+ *
+ * - Manages dialog stacking when one-at-a-time just isn't enough.
+ * - Creates a backdrop, for disabling interaction below the modal.
+ * - It properly manages focus; moving to the modal content, and keeping it there until the modal is closed.
+ * - It disables scrolling of the page content while open.
+ * - Adds the appropriate ARIA roles are automatically.
+ * - Easily pluggable animations via a `<Transition/>` component.
+ *
+ * Note that, in the same way the backdrop element prevents users from clicking or interacting
+ * with the page content underneath the Modal, Screen readers also need to be signaled to not to
+ * interact with page content while the Modal is open. To do this, we use a common technique of applying
+ * the `aria-hidden='true'` attribute to the non-Modal elements in the Modal `container`. This means that for
+ * a Modal to be truly modal, it should have a `container` that is _outside_ your app's
+ * React hierarchy (such as the default: document.body).
+ */
+class ModalMotion extends React.Component {
+
+  static propTypes = {
+    ...Portal.propTypes,
+
+    /**
+     * Set the visibility of the Modal
+     */
+    show: PropTypes.bool,
+
+    /**
+     * A Node, Component instance, or function that returns either. The Modal is appended to it's container element.
+     *
+     * For the sake of assistive technologies, the container should usually be the document body, so that the rest of the
+     * page content can be placed behind a virtual backdrop as well as a visual one.
+     */
+    container: PropTypes.oneOfType([
+      componentOrElement,
+      PropTypes.func
+    ]),
+
+    /**
+     * A callback fired when the Modal is opening.
+     */
+    onShow: PropTypes.func,
+
+
+    /**
+     * A callback fired when either the backdrop is clicked, or the escape key is pressed.
+     *
+     * The `onHide` callback only signals intent from the Modal,
+     * you must actually set the `show` prop to `false` for the Modal to close.
+     */
+    onHide: PropTypes.func,
+
+    /**
+     * Include a backdrop component.
+     */
+    backdrop: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf(['static'])
+    ]),
+
+    /**
+     * A function that returns a backdrop component. Useful for custom
+     * backdrop rendering.
+     *
+     * ```js
+     *  renderBackdrop={props => <MyBackdrop {...props} />}
+     * ```
+     */
+    renderBackdrop: PropTypes.func,
+
+    /**
+     * A callback fired when the escape key, if specified in `keyboard`, is pressed.
+     */
+    onEscapeKeyDown: PropTypes.func,
+
+    /**
+     * Support for this function will be deprecated. Please use `onEscapeKeyDown` instead
+     * A callback fired when the escape key, if specified in `keyboard`, is pressed.
+     * @deprecated
+     */
+    onEscapeKeyUp: deprecated(
+      PropTypes.func,
+      'Please use onEscapeKeyDown instead for consistency'
+    ),
+
+    /**
+     * A callback fired when the backdrop, if specified, is clicked.
+     */
+    onBackdropClick: PropTypes.func,
+
+    /**
+     * A style object for the backdrop component.
+     */
+    backdropStyle: PropTypes.object,
+
+    /**
+     * A css class or classes for the backdrop component.
+     */
+    backdropClassName: PropTypes.string,
+
+    /**
+     * A css class or set of classes applied to the modal container when the modal is open,
+     * and removed when it is closed.
+     */
+    containerClassName: PropTypes.string,
+
+    /**
+     * Close the modal when escape key is pressed
+     */
+    keyboard: PropTypes.bool,
+
+    /**
+     * A `react-transition-group@2.0.0` `<Transition/>` component used
+     * to control animations for the dialog component.
+     */
+    transition: elementType,
+
+    /**
+     * A `react-transition-group@2.0.0` `<Transition/>` component used
+     * to control animations for the backdrop components.
+     */
+    backdropTransition: elementType,
+
+
+    /**
+     * When `true` The modal will automatically shift focus to itself when it opens, and
+     * replace it to the last focused element when it closes. This also
+     * works correctly with any Modal children that have the `autoFocus` prop.
+     *
+     * Generally this should never be set to `false` as it makes the Modal less
+     * accessible to assistive technologies, like screen readers.
+     */
+    autoFocus: PropTypes.bool,
+
+    /**
+     * When `true` The modal will prevent focus from leaving the Modal while open.
+     *
+     * Generally this should never be set to `false` as it makes the Modal less
+     * accessible to assistive technologies, like screen readers.
+     */
+    enforceFocus: PropTypes.bool,
+
+    /**
+     * When `true` The modal will restore focus to previously focused element once
+     * modal is hidden
+     */
+    restoreFocus: PropTypes.bool,
+
+    /**
+     * Callback fired before the Modal transitions in
+     */
+    onEnter: PropTypes.func,
+
+    /**
+     * Callback fired as the Modal begins to transition in
+     */
+    onEntering: PropTypes.func,
+
+    /**
+     * Callback fired after the Modal finishes transitioning in
+     */
+    onEntered: PropTypes.func,
+
+    /**
+     * Callback fired right before the Modal transitions out
+     */
+    onExit: PropTypes.func,
+
+    /**
+     * Callback fired as the Modal begins to transition out
+     */
+    onExiting: PropTypes.func,
+
+    /**
+     * Callback fired after the Modal finishes transitioning out
+     */
+    onExited: PropTypes.func,
+
+    /**
+     * A ModalManager instance used to track and manage the state of open
+     * Modals. Useful when customizing how modals interact within a container
+     */
+    manager: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    show: false,
+    backdrop: true,
+    keyboard: true,
+    autoFocus: true,
+    enforceFocus: true,
+    restoreFocus: true,
+    onHide: ()=>{},
+    manager: modalManager,
+    renderBackdrop: (props) => <div {...props} />
+  };
+
+  omitProps(props, propTypes) {
+
+    const keys = Object.keys(props);
+    const newProps = {};
+    keys.map((prop) => {
+      if (!Object.prototype.hasOwnProperty.call(propTypes, prop)) {
+        newProps[prop] = props[prop];
+      }
+    });
+
+    return newProps;
+  }
+
+  state = {exited: !this.props.show};
+
+  render() {
+    const {
+      show,
+      container,
+      children,
+      transition: TransitionMotion,
+      backdrop,
+      className,
+      style,
+    } = this.props;
+
+    let dialog = React.Children.only(children);
+    const filteredProps = this.omitProps(this.props, ModalMotion.propTypes);
+
+    const mountModal = show || (TransitionMotion && !this.state.exited);
+    if (!mountModal) {
+      return null;
+    }
+
+    const { role, tabIndex } = dialog.props;
+
+    if (role === undefined || tabIndex === undefined) {
+      dialog = cloneElement(dialog, {
+        role: role === undefined ? 'document' : role,
+        tabIndex: tabIndex == null ? '-1' : tabIndex
+      });
+    }
+
+    if (TransitionMotion) {
+      dialog = (
+        <TransitionMotion
+          appear
+          unmountOnExit
+          in={show}
+        >
+          {dialog}
+        </TransitionMotion>
+      );
+    }
+
+
+    return (
+      <Portal
+        ref={this.setMountNode}
+        container={container}
+        onRendered={this.onPortalRendered}
+      >
+        <div
+          ref={this.setModalNodeRef}
+          role={role || 'dialog'}
+          {...filteredProps}
+          style={style}
+          className={className}
+        >
+          {backdrop && this.renderBackdrop()}
+          <RefHolder ref={this.setDialogRef}>
+            {dialog}
+          </RefHolder>
+        </div>
+      </Portal>
+    );
+  }
+
+  renderBackdrop = () => {
+    let {
+      backdropStyle,
+      backdropClassName,
+      renderBackdrop,
+      backdropTransition: TransitionMotion } = this.props;
+
+    const backdropRef = ref => this.backdrop = ref;
+
+    let backdrop = renderBackdrop({
+      ref: backdropRef,
+      style: backdropStyle,
+      className: backdropClassName,
+      onClick: this.handleBackdropClick,
+    });
+
+  
+    if (TransitionMotion) {
+      backdrop = (
+        <TransitionMotion
+          appear
+          in={this.props.show}
+        >
+          {backdrop}
+        </TransitionMotion>
+      );
+    }
+
+    return backdrop;
+  };
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.show) {
+      this.setState({exited: false});
+    } else {
+      // Otherwise let handleHidden take care of marking exited.
+      this.setState({exited: true});
+    }
+  }
+
+  componentWillUpdate(nextProps) {
+    if (!this.props.show && nextProps.show) {
+      this.checkForFocus();
+    }
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+    if (this.props.show) {
+      this.onShow();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    let { transition } = this.props;
+
+    if ( prevProps.show && !this.props.show && !transition) {
+      // Otherwise handleHidden will call this.
+      this.onHide();
+    }
+    else if (!prevProps.show && this.props.show) {
+      this.onShow();
+    }
+  }
+
+  componentWillUnmount() {
+    let { show, transition } = this.props;
+
+    this._isMounted = false;
+
+    if (show || (transition && !this.state.exited)) {
+      this.onHide();
+    }
+  }
+
+  onPortalRendered = () => {
+    this.autoFocus();
+
+    if (this.props.onShow) {
+      this.props.onShow();
+    }
+  };
+
+  onShow = () => {
+    let doc = ownerDocument(this);
+    let container = getContainer(this.props.container, doc.body);
+
+    this.props.manager.add(this, container, this.props.containerClassName);
+
+    this._onDocumentKeydownListener =
+      addEventListener(doc, 'keydown', this.handleDocumentKeyDown);
+
+    this._onDocumentKeyupListener =
+      addEventListener(doc, 'keyup', this.handleDocumentKeyUp);
+
+    this._onFocusinListener =
+      addFocusListener(this.enforceFocus);
+  };
+
+  onHide = () => {
+    this.props.manager.remove(this);
+
+    this._onDocumentKeydownListener.remove();
+
+    this._onDocumentKeyupListener.remove();
+
+    this._onFocusinListener.remove();
+
+    if (this.props.restoreFocus) {
+      this.restoreLastFocus();
+    }
+  };
+
+  setMountNode = (ref) => {
+    this.mountNode = ref ? ref.getMountNode() : ref;
+  };
+
+  setModalNodeRef = (ref) => {
+    this.modalNode = ref;
+  };
+
+  setDialogRef = (ref) => {
+    this.dialog = ref;
+  };
+
+  handleHidden = (...args) => {
+    this.setState({ exited: true });
+    this.onHide();
+
+    if (this.props.onExited) {
+      this.props.onExited(...args);
+    }
+  };
+
+  handleBackdropClick = (e) => {
+    if (e.target !== e.currentTarget) {
+      return;
+    }
+
+    if (this.props.onBackdropClick) {
+      this.props.onBackdropClick(e);
+    }
+
+    if (this.props.backdrop === true){
+      this.props.onHide();
+    }
+  };
+
+  handleDocumentKeyDown = (e) => {
+    if (this.props.keyboard && e.keyCode === 27 && this.isTopModal()) {
+      if (this.props.onEscapeKeyDown) {
+        this.props.onEscapeKeyDown(e);
+      }
+
+      this.props.onHide();
+    }
+  };
+
+  handleDocumentKeyUp = (e) => {
+    if (this.props.keyboard && e.keyCode === 27 && this.isTopModal()) {
+      if (this.props.onEscapeKeyUp) {
+        this.props.onEscapeKeyUp(e);
+      }
+    }
+  };
+
+  checkForFocus = () => {
+    if (canUseDom) {
+      this.lastFocus = activeElement();
+    }
+  };
+
+  autoFocus() {
+    if (!this.props.autoFocus) {
+      return;
+    }
+
+    const dialogElement = this.getDialogElement();
+    const currentActiveElement = activeElement(ownerDocument(this));
+
+    if (dialogElement && !contains(dialogElement, currentActiveElement)) {
+      this.lastFocus = currentActiveElement;
+
+      if (!dialogElement.hasAttribute('tabIndex')) {
+        warning(
+          false,
+          'The modal content node does not accept focus. For the benefit of ' +
+          'assistive technologies, the tabIndex of the node is being set ' +
+          'to "-1".'
+        );
+
+        dialogElement.setAttribute('tabIndex', -1);
+      }
+
+      dialogElement.focus();
+    }
+  }
+
+  restoreLastFocus() {
+    // Support: <=IE11 doesn't support `focus()` on svg elements (RB: #917)
+    if (this.lastFocus && this.lastFocus.focus) {
+      this.lastFocus.focus();
+      this.lastFocus = null;
+    }
+  }
+
+  enforceFocus = () => {
+    if (
+      !this.props.enforceFocus ||
+      !this._isMounted ||
+      !this.isTopModal()
+    ) {
+      return;
+    }
+
+    const dialogElement = this.getDialogElement();
+    const currentActiveElement = activeElement(ownerDocument(this));
+
+    if (dialogElement && !contains(dialogElement, currentActiveElement)) {
+      dialogElement.focus();
+    }
+  };
+
+  getDialogElement() {
+    return ReactDOM.findDOMNode(this.dialog);
+  }
+
+  isTopModal() {
+    return this.props.manager.isTopModal(this);
+  }
+}
+
+ModalMotion.Manager = ModalManager;
+
+export default ModalMotion;

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -76,7 +76,6 @@ class Overlay extends React.Component {
         </Transition>
       );
     }
-
     // This goes after everything else because it adds a wrapping div.
     if (rootClose) {
       child = (

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export Affix from './Affix';
 export AutoAffix from './AutoAffix';
 export Modal from './Modal';
+export ModalMotion from './ModalMotion';
 export Overlay from './Overlay';
 export Portal from './Portal';
 export Position from './Position';


### PR DESCRIPTION
Integration react-overlays with react-motion

POC done to integrate react-motion with overlay.
As of now, react-overlay is bound to react-transition-group directly.
This experiment  to verify if the same API can be used along with react-motion

* Picked TransitionMotion API of react-motion as its almost similar to transition
-group.
* A new module is added for ModalMotion.js which takes motion as the input.
* TransitionModel.js example shows how to use react-motion here.

May have few bugs..!