### PR TITLE
Affix - Fixed the problem of page flashing when scroll page.

### DIFF
--- a/src/Affix.js
+++ b/src/Affix.js
@@ -81,7 +81,11 @@ class Affix extends React.Component {
     const {offsetTop, viewportOffsetTop} = this.props;
     const scrollTop = getScrollTop(ownerWindow(this));
     const positionTopMin = scrollTop + (viewportOffsetTop || 0);
-
+    
+    if (this.state.position === 'fixed') {
+       positionTopMin += getHeight(ReactDOM.findDOMNode(this));
+    }
+    
     if (positionTopMin <= offsetTop) {
       this.updateState('top', null, null);
       return;


### PR DESCRIPTION
If the Affix element is fixed, the scrollTop will be reduced, and the `positionTopMin` may be less than `offsetTop`, Affix element will back to the original position. so the page will flash when repeated scrolling.