### PR TITLE
Render context consumer instead of context itself

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -189,7 +189,7 @@ class DropdownMenu extends React.Component {
 }
 
 const DecoratedDropdownMenu = mapContextToProps(
-  DropdownContext,
+  DropdownContext.Consumer,
   ({ show, alignEnd, toggle, drop, menuRef, toggleNode }, props) => ({
     drop,
     menuRef,


### PR DESCRIPTION
React 16.6 has a deprecation warning about rendering context directly

Fixes https://github.com/react-bootstrap/react-bootstrap/issues/3347