### PR TITLE
Add restoreFocusOptions prop to Modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -163,6 +163,15 @@ class Modal extends React.Component {
     restoreFocus: PropTypes.bool,
 
     /**
+     * Options passed to focus function when `restoreFocus` is set to `true`
+     *
+     * @link  https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Parameters
+     */
+    restoreFocusOptions: PropTypes.shape({
+      preventScroll: PropTypes.bool,
+    }),
+
+    /**
      * Callback fired before the Modal transitions in
      */
     onEnter: PropTypes.func,
@@ -297,7 +306,7 @@ class Modal extends React.Component {
     this.removeFocusListener();
 
     if (this.props.restoreFocus) {
-      this.restoreLastFocus();
+      this.restoreLastFocus(this.props.restoreFocusOption);
     }
   };
 
@@ -353,10 +362,10 @@ class Modal extends React.Component {
     }
   }
 
-  restoreLastFocus() {
+  restoreLastFocus(focusOptions) {
     // Support: <=IE11 doesn't support `focus()` on svg elements (RB: #917)
     if (this.lastFocus && this.lastFocus.focus) {
-      this.lastFocus.focus();
+      this.lastFocus.focus(focusOptions);
       this.lastFocus = null;
     }
   }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -216,7 +216,6 @@ class Modal extends React.Component {
     autoFocus: true,
     enforceFocus: true,
     restoreFocus: true,
-    restoreFocusOptions: {},
     onHide: () => {},
     manager: modalManager,
     renderBackdrop: props => <div {...props} />,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -216,6 +216,7 @@ class Modal extends React.Component {
     autoFocus: true,
     enforceFocus: true,
     restoreFocus: true,
+    restoreFocusOptions: {},
     onHide: () => {},
     manager: modalManager,
     renderBackdrop: props => <div {...props} />,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -306,7 +306,7 @@ class Modal extends React.Component {
     this.removeFocusListener();
 
     if (this.props.restoreFocus) {
-      this.restoreLastFocus(this.props.restoreFocusOption);
+      this.restoreLastFocus();
     }
   };
 
@@ -362,10 +362,10 @@ class Modal extends React.Component {
     }
   }
 
-  restoreLastFocus(focusOptions) {
+  restoreLastFocus() {
     // Support: <=IE11 doesn't support `focus()` on svg elements (RB: #917)
     if (this.lastFocus && this.lastFocus.focus) {
-      this.lastFocus.focus(focusOptions);
+      this.lastFocus.focus(this.props.restoreFocusOptions);
       this.lastFocus = null;
     }
   }


### PR DESCRIPTION
This PR will allow the developers to have better control over scroll restoration when using [`react-bootstrap/Modal`](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Modal.js).

By default, `focus()` will scroll the element into the visible area of the browser window. It can result in unexpected jumps when using [`react-bootstrap/Modal`](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Modal.js) with `react-router`. Exposing focus options as a prop will allow developers to have control over the [`preventScroll`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Parameters) parameter.