### PR TITLE
Make sure menu ref is set before accessing this.menu.contains

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -201,7 +201,8 @@ class Dropdown extends React.Component {
     const isInput = /input|textarea/i.test(target.tagName);
     if (
       isInput &&
-      (key === ' ' || (key !== 'Escape' && this.menu.contains(target)))
+      (key === ' ' ||
+        (key !== 'Escape' && this.menu && this.menu.contains(target)))
     ) {
       return;
     }


### PR DESCRIPTION
On [line 204 in `/src/dropdown.js`](https://github.com/react-bootstrap/react-overlays/blob/master/src/Dropdown.js#L204) you are trying to access `this.menu.contains`. This will throw an error when `this.menu` is not set.

```javascript
if (isInput && (key === ' ' || key !== 'Escape' && _this.menu.contains(target)))
```

---

Logs from my project:

```
Uncaught TypeError: Cannot read property 'contains' of null
    at Dropdown._this.handleKeyDown (Dropdown.js:209)
    at HTMLUnknownElement.callCallback (react-dom.development.js:147)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:196)
    at invokeGuardedCallback (react-dom.development.js:250)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:265)
    at executeDispatch (react-dom.development.js:571)
    at executeDispatchesInOrder (react-dom.development.js:596)
    at executeDispatchesAndRelease (react-dom.development.js:695)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:704)
    at forEachAccumulated (react-dom.development.js:676)
    at runEventsInBatch (react-dom.development.js:844)
    at runExtractedEventsInBatch (react-dom.development.js:852)
    at handleTopLevel (react-dom.development.js:5030)
    at batchedUpdates$1 (react-dom.development.js:21425)
    at batchedUpdates (react-dom.development.js:2247)
    at dispatchEvent (react-dom.development.js:5110)
    at react-dom.development.js:21482
    at Object.unstable_runWithPriority (scheduler.development.js:255)
    at interactiveUpdates$1 (react-dom.development.js:21481)
    at interactiveUpdates (react-dom.development.js:2268)
    at dispatchInteractiveEvent (react-dom.development.js:5086)
```