### PR TITLE
Fix #292: modal shouldn't make itself aria-hidden

### DIFF
--- a/src/utils/manageAriaHidden.js
+++ b/src/utils/manageAriaHidden.js
@@ -1,30 +1,30 @@
-const BLACKLIST = ['template', 'script', 'style']
+const BLACKLIST = ['template', 'script', 'style'];
 
 let isHidable = ({ nodeType, tagName }) =>
-  nodeType === 1 && BLACKLIST.indexOf(tagName.toLowerCase()) === -1
+  nodeType === 1 && BLACKLIST.indexOf(tagName.toLowerCase()) === -1;
 
 let siblings = (container, exclude, cb) => {
-  exclude = [].concat(exclude)
-  ;[].forEach.call(container.children, node => {
+  exclude = [].concat(exclude);
+  [].forEach.call(container.children, node => {
     if (exclude.indexOf(node) === -1 && isHidable(node)) {
-      cb(node)
+      cb(node);
     }
-  })
-}
+  });
+};
 
 export function ariaHidden(show, node) {
-  if (!node) return
+  if (!node) return;
   if (show) {
-    node.setAttribute('aria-hidden', 'true')
+    node.setAttribute('aria-hidden', 'true');
   } else {
-    node.removeAttribute('aria-hidden')
+    node.removeAttribute('aria-hidden');
   }
 }
 
-export function hideSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(true, node))
+export function hideSiblings(container, { dialog: root, backdrop }) {
+  siblings(container, [root, backdrop], node => ariaHidden(true, node));
 }
 
-export function showSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(false, node))
+export function showSiblings(container, { dialog: root, backdrop }) {
+  siblings(container, [root, backdrop], node => ariaHidden(false, node));
 }


### PR DESCRIPTION
Fixes #292 

Not sure where to add a test for this within this repo but making this change manually in my local project dependency did get rid of the `aria-hidden="true"` on the root `<div role="dialog" aria-modal="true">` element

