### PR TITLE
Install www dependencies in install hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
-after_install:
+before_script:
   - cd www
   - yarn
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,8 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 
-before_script:
-  - cd www
-  - yarn
+install:
+  - yarn --cwd www
 
 after_script:
   - node_modules/.bin/codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - stable
+  - node
 
 env:
   - BROWSER=ChromeCi
@@ -15,6 +15,10 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+after_install:
+  - cd www
+  - yarn
 
 after_script:
   - node_modules/.bin/codecov


### PR DESCRIPTION
The problem with broken build are not installed dependencies in www.
As a solution I suggest to run yarn for www after installing
dependencies on CI.