### PR TITLE
ci: add github actions and integrate semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release New Version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    steps:
+      - name: Checking out Repository
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Install Dependencies
+        run: yarn bootstrap
+      - name: Build Production Files
+        run: yarn build
+      - name: Release To NPM and GitHub
+        run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+on: [push]
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        browser: [ChromeHeadless]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - name: Checking out Repository
+      uses: actions/checkout@v1
+    - name: Setup Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install Chrome (macOS)
+      if: matrix.os == 'macOS-latest'
+      run: brew cask install google-chrome
+    - name: Install Dependencies
+      run: yarn bootstrap
+    - name: Run Tests
+      run: yarn test
+      env:
+        BROWSER: ${{ matrix.browser }}
+    - name: Upload Test Coverage to codecov
+      # Only upload it a single time
+      if: matrix.os == 'ubuntu-latest'
+      run: yarn run codecov


### PR DESCRIPTION
Relevant to 4324 in the React-Bootstrap repository.

Adds github actions, with a workflow for running tests and a
workflow for release.

For the release workflow, there is an integration with
semantic-release. We would need to need to setup two github
secrets for semantic to work properly: `NPM_TOKEN` and `GH_TOKEN`.