### PR TITLE
Mismatch between Modal.dialog and hideSiblings parameters

### DIFF
--- a/src/utils/manageAriaHidden.js
+++ b/src/utils/manageAriaHidden.js
@@ -21,10 +21,10 @@ export function ariaHidden(show, node) {
   }
 }
 
-export function hideSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(true, node));
+export function hideSiblings(container, { dialog, backdrop }) {
+  siblings(container, [dialog, backdrop], node => ariaHidden(true, node));
 }
 
-export function showSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(false, node));
+export function showSiblings(container, { dialog, backdrop }) {
+  siblings(container, [dialog, backdrop], node => ariaHidden(false, node));
 }

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -112,6 +112,17 @@ describe('ModalManager', () => {
       expect(app.getAttribute('aria-hidden')).to.equal('true');
     });
 
+    it('should not add aria-hidden to modal', () => {
+      let modal = new Modal({});
+      let mount = document.createElement('div');
+
+      modal.dialog = mount;
+      container.appendChild(mount);
+      manager.add(modal, container);
+
+      expect(modal.dialog.getAttribute('aria-hidden')).to.equal(null);
+    });
+
     it('should add aria-hidden to previous modals', () => {
       let modalA = new Modal({});
       let mount = document.createElement('div');


### PR DESCRIPTION
Fixes the issue raised here: https://github.com/react-bootstrap/react-overlays/issues/240

The modal component contains refs to `dialog` and `backdrop` https://github.com/omniverse/react-overlays/blob/master/src/Modal.js#L309-L315
not `root` and `backdrop` as destructured in manageAriaHidden https://github.com/omniverse/react-overlays/blob/master/src/Modal.js#L309-L315

So the aria-hidden="true" attribute was getting applied to the dialog itself and breaking screen readers, accessibility features, etc.