### PR TITLE
fix(docs): compilation issues when building production files

### DIFF
--- a/src/utils/useWaitForDOMRef.js
+++ b/src/utils/useWaitForDOMRef.js
@@ -2,7 +2,7 @@ import ownerDocument from 'dom-helpers/ownerDocument';
 import { useState, useEffect } from 'react';
 
 const resolveRef = ref => {
-  if(typeof document === 'undefined') return undefined;
+  if (typeof document === 'undefined') return undefined;
   if (ref == null) return ownerDocument().body;
   if (typeof ref === 'function') ref = ref();
 

--- a/src/utils/useWaitForDOMRef.js
+++ b/src/utils/useWaitForDOMRef.js
@@ -2,6 +2,7 @@ import ownerDocument from 'dom-helpers/ownerDocument';
 import { useState, useEffect } from 'react';
 
 const resolveRef = ref => {
+  if(typeof document === 'undefined') return undefined;
   if (ref == null) return ownerDocument().body;
   if (typeof ref === 'function') ref = ref();
 


### PR DESCRIPTION
This was due to `ownerDocument` using `document` when it wasn't
defined (which is the case when building production files).