### PR TITLE
ci(actions): fix for build not triggering on forked pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Run Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   test:
     name: Run Testing Suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Run Tests
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     name: Run Testing Suite


### PR DESCRIPTION
Currently, the build is only being triggered whenever there is
a push to the repository.

This does not lead to a build being triggered whenever there is a
push to a branch on a forked repo.

This fix allows it to trigger on every push *or* every pull
request.

We'll probably need to also fix the configuration on the
React-Bootstrap repo.