### PR TITLE
Drop warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "dom-helpers": "^5.1.0",
     "popper.js": "^1.15.0",
     "prop-types": "^15.7.2",
-    "uncontrollable": "^7.0.0",
-    "warning": "^4.0.3"
+    "uncontrollable": "^7.0.0"
   },
   "peerDependencies": {
     "react": ">=16.3.0",

--- a/src/useRootClose.js
+++ b/src/useRootClose.js
@@ -3,7 +3,6 @@ import listen from 'dom-helpers/listen';
 import { useCallback, useEffect, useRef } from 'react';
 
 import useEventCallback from '@restart/hooks/useEventCallback';
-import warning from 'warning';
 
 const escapeKeyCode = 27;
 const noop = () => {};
@@ -39,11 +38,14 @@ function useRootClose(
   const handleMouseCapture = useCallback(
     e => {
       const currentTarget = ref && ('current' in ref ? ref.current : ref);
-      warning(
-        !!currentTarget,
-        'RootClose captured a close event but does not have a ref to compare it to. ' +
-          'useRootClose(), should be passed a ref that resolves to a DOM node',
-      );
+      if (process.env.NODE_ENV !== 'production') {
+        if (!currentTarget) {
+          console.error(
+            'RootClose captured a close event but does not have a ref to compare it to. ' +
+              'useRootClose(), should be passed a ref that resolves to a DOM node',
+          );
+        }
+      }
 
       preventMouseRootCloseRef.current =
         !currentTarget ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -10354,13 +10354,6 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-warning@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
-  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
-  dependencies:
-    loose-envify "^1.0.0"
-
 watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"


### PR DESCRIPTION
I tend to remove warning because of confusing api. It's hard to say by
which condition warning is shown. This package also requires babel
plugin setup which is forgotted here. IMO it's much easier to just write
console statement and choose either console.warn or console.error than
dealing with this commonjs-only package.