### PR TITLE
fix(0.x): missed UNSAFE lifecycle in Portal (React 17)

### DIFF
--- a/src/Portal.js
+++ b/src/Portal.js
@@ -30,7 +30,7 @@ class Portal extends React.Component {
     onRendered: PropTypes.func,
   };
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     if (!canUseDom) {
       return;
     }


### PR DESCRIPTION
#597 missed this lifecycle method.