### PR TITLE
feat: improve popper integration

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -116,12 +116,12 @@ export function useDropdownMenu(options: UseDropdownMenuOptions = {}) {
       ...childArgs,
       props: {
         ...menuProps,
-        ...(attributes.popper || {}),
+        ...attributes.popper,
         style: styles.popper as any,
       },
       arrowProps: {
         ref: attachArrowRef,
-        ...(attributes.arrow || {}),
+        ...attributes.arrow,
         style: styles.arrow as any,
       },
     };

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -118,12 +118,12 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
       ...popper,
       show: !!props.show,
       props: {
-        ...(attributes.popper || {}),
+        ...attributes.popper,
         style: styles.popper as any,
         ref: mergedRef,
       },
       arrowProps: {
-        ...(attributes.arrow || {}),
+        ...attributes.arrow,
         style: styles.arrow as any,
         ref: attachArrowRef,
       },

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -5,17 +5,20 @@ import useCallbackRef from '@restart/hooks/useCallbackRef';
 import useMergedRefs from '@restart/hooks/useMergedRefs';
 import { placements } from './popper';
 import usePopper, {
-  toModifierMap,
   Placement,
   UsePopperOptions,
+  Offset,
+  State,
 } from './usePopper';
 import useRootClose, { RootCloseOptions } from './useRootClose';
 import useWaitForDOMRef, { DOMContainer } from './useWaitForDOMRef';
 import { TransitionCallbacks } from './types';
+import mergeOptionsWithPopperConfig from './mergeOptionsWithPopperConfig';
 
 export interface OverlayProps extends TransitionCallbacks {
   flip?: boolean;
   placement?: Placement;
+  offset?: Offset;
   containerPadding?: number;
   popperConfig?: Omit<UsePopperOptions, 'placement'>;
   container?: DOMContainer;
@@ -31,14 +34,15 @@ export interface OverlayProps extends TransitionCallbacks {
   children: (value: {
     show: boolean;
     placement: Placement;
-    outOfBoundaries: boolean;
-    scheduleUpdate: () => void;
-    props: {
+    update: () => void;
+    forceUpdate: () => void;
+    state?: State;
+    props: Record<string, any> & {
       ref: React.RefCallback<HTMLElement>;
       style: React.CSSProperties;
       'aria-labelledby'?: string;
     };
-    arrowProps: {
+    arrowProps: Record<string, any> & {
       ref: React.RefCallback<HTMLElement>;
       style: React.CSSProperties;
     };
@@ -49,118 +53,104 @@ export interface OverlayProps extends TransitionCallbacks {
  * Built on top of `Popper.js`, the overlay component is
  * great for custom tooltip overlays.
  */
-const Overlay = React.forwardRef((props: OverlayProps, outerRef) => {
-  const {
-    flip,
-    placement,
-    containerPadding = 5,
-    popperConfig = {},
-    transition: Transition,
-  } = props;
+const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
+  (props, outerRef) => {
+    const {
+      flip,
+      offset,
+      placement,
+      containerPadding = 5,
+      popperConfig = {},
+      transition: Transition,
+    } = props;
 
-  const [rootElement, attachRef] = useCallbackRef<HTMLElement>();
-  const [arrowElement, attachArrowRef] = useCallbackRef();
-  const mergedRef = useMergedRefs(attachRef, outerRef);
+    const [rootElement, attachRef] = useCallbackRef<HTMLElement>();
+    const [arrowElement, attachArrowRef] = useCallbackRef<Element>();
+    const mergedRef = useMergedRefs<HTMLElement | null>(attachRef, outerRef);
 
-  const container = useWaitForDOMRef(props.container);
-  const target = useWaitForDOMRef(props.target);
+    const container = useWaitForDOMRef(props.container);
+    const target = useWaitForDOMRef(props.target);
 
-  const [exited, setExited] = useState(!props.show);
+    const [exited, setExited] = useState(!props.show);
 
-  const modifiers = toModifierMap(popperConfig.modifiers);
-
-  const { styles, arrowStyles, ...popper } = usePopper(target, rootElement, {
-    ...popperConfig,
-    placement: placement || 'bottom',
-
-    modifiers: {
-      ...modifiers,
-      eventListeners: {
-        enabled: !!props.show,
-      },
-      preventOverflow: {
-        ...modifiers.preventOverflow,
-        options: {
-          padding: containerPadding || 5,
-          ...modifiers.preventOverflow?.options,
-        },
-      },
-      arrow: {
-        ...modifiers.arrow,
-        enabled: !!arrowElement,
-        options: {
-          ...modifiers.arrow?.options,
-          element: arrowElement,
-        },
-      },
-      flip: {
-        enabled: !!flip,
-        ...modifiers.flip,
-      },
-    },
-  });
-
-  if (props.show) {
-    if (exited) setExited(false);
-  } else if (!props.transition && !exited) {
-    setExited(true);
-  }
-
-  const handleHidden: TransitionCallbacks['onExited'] = (...args) => {
-    setExited(true);
-
-    if (props.onExited) {
-      props.onExited(...args);
-    }
-  };
-
-  // Don't un-render the overlay while it's transitioning out.
-  const mountOverlay = props.show || (Transition && !exited);
-
-  useRootClose(rootElement, props.onHide!, {
-    disabled: !props.rootClose || props.rootCloseDisabled,
-    clickTrigger: props.rootCloseEvent,
-  });
-
-  if (!mountOverlay) {
-    // Don't bother showing anything if we don't have to.
-    return null;
-  }
-
-  let child = props.children({
-    ...popper,
-    show: !!props.show,
-    props: {
-      style: styles as any,
-      ref: mergedRef,
-    },
-    arrowProps: {
-      style: arrowStyles as any,
-      ref: attachArrowRef,
-    },
-  });
-
-  if (Transition) {
-    const { onExit, onExiting, onEnter, onEntering, onEntered } = props;
-
-    child = (
-      <Transition
-        in={props.show}
-        appear
-        onExit={onExit}
-        onExiting={onExiting}
-        onExited={handleHidden}
-        onEnter={onEnter}
-        onEntering={onEntering}
-        onEntered={onEntered}
-      >
-        {child}
-      </Transition>
+    const { styles, attributes, ...popper } = usePopper(
+      target,
+      rootElement,
+      mergeOptionsWithPopperConfig({
+        placement,
+        enableEvents: !!props.show,
+        containerPadding: containerPadding || 5,
+        flip,
+        offset,
+        arrowElement,
+        popperConfig,
+      }),
     );
-  }
 
-  return container ? ReactDOM.createPortal(child, container) : null;
-});
+    if (props.show) {
+      if (exited) setExited(false);
+    } else if (!props.transition && !exited) {
+      setExited(true);
+    }
+
+    const handleHidden: TransitionCallbacks['onExited'] = (...args) => {
+      setExited(true);
+
+      if (props.onExited) {
+        props.onExited(...args);
+      }
+    };
+
+    // Don't un-render the overlay while it's transitioning out.
+    const mountOverlay = props.show || (Transition && !exited);
+
+    useRootClose(rootElement, props.onHide!, {
+      disabled: !props.rootClose || props.rootCloseDisabled,
+      clickTrigger: props.rootCloseEvent,
+    });
+
+    if (!mountOverlay) {
+      // Don't bother showing anything if we don't have to.
+      return null;
+    }
+
+    let child = props.children({
+      ...popper,
+      show: !!props.show,
+      props: {
+        ...(attributes.popper || {}),
+        style: styles.popper as any,
+        ref: mergedRef,
+      },
+      arrowProps: {
+        ...(attributes.arrow || {}),
+        style: styles.arrow as any,
+        ref: attachArrowRef,
+      },
+    });
+
+    if (Transition) {
+      const { onExit, onExiting, onEnter, onEntering, onEntered } = props;
+
+      child = (
+        <Transition
+          in={props.show}
+          appear
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={handleHidden}
+          onEnter={onEnter}
+          onEntering={onEntering}
+          onEntered={onEntered}
+        >
+          {child}
+        </Transition>
+      );
+    }
+
+    return container ? ReactDOM.createPortal(child, container) : null;
+  },
+);
 
 Overlay.displayName = 'Overlay';
 
@@ -199,16 +189,18 @@ Overlay.propTypes = {
    * @type {Function ({
    *   show: boolean,
    *   placement: Placement,
-   *   outOfBoundaries: ?boolean,
-   *   scheduleUpdate: () => void,
+   *   update: () => void,
+   *   forceUpdate: () => void,
    *   props: {
    *     ref: (?HTMLElement) => void,
    *     style: { [string]: string | number },
    *     aria-labelledby: ?string
+   *     [string]: string | number,
    *   },
    *   arrowProps: {
    *     ref: (?HTMLElement) => void,
    *     style: { [string]: string | number },
+   *     [string]: string | number,
    *   },
    * }) => React.Element}
    */

--- a/src/mergeOptionsWithPopperConfig.ts
+++ b/src/mergeOptionsWithPopperConfig.ts
@@ -1,0 +1,88 @@
+import { UsePopperOptions, Offset, Placement, Modifiers } from './usePopper';
+
+export type Config = {
+  flip?: boolean;
+  show?: boolean;
+  alignEnd?: boolean;
+  enabled?: boolean;
+  containerPadding?: number;
+  arrowElement?: Element | null;
+  enableEvents?: boolean;
+  offset?: Offset;
+  placement?: Placement;
+  popperConfig?: UsePopperOptions;
+};
+
+export function toModifierMap(modifiers: Modifiers | undefined) {
+  const result: Modifiers = {};
+
+  if (!Array.isArray(modifiers)) {
+    return modifiers || result;
+  }
+
+  // eslint-disable-next-line no-unused-expressions
+  modifiers?.forEach((m) => {
+    result[m.name!] = m;
+  });
+  return result;
+}
+
+export function toModifierArray(map: Modifiers | undefined = {}) {
+  if (Array.isArray(map)) return map;
+  return Object.keys(map).map((k) => {
+    map[k].name = k;
+    return map[k];
+  });
+}
+
+export default function mergeOptionsWithPopperConfig({
+  enabled,
+  enableEvents,
+  placement,
+  flip,
+  offset,
+  containerPadding,
+  arrowElement,
+  popperConfig = {},
+}: Config): UsePopperOptions {
+  const modifiers = toModifierMap(popperConfig.modifiers);
+
+  return {
+    ...popperConfig,
+    placement,
+    enabled,
+    modifiers: toModifierArray({
+      ...modifiers,
+      eventListeners: {
+        enabled: enableEvents,
+      },
+      preventOverflow: {
+        ...modifiers.preventOverflow,
+        options: containerPadding
+          ? {
+              padding: containerPadding,
+              ...modifiers.preventOverflow?.options,
+            }
+          : modifiers.preventOverflow?.options,
+      },
+      offset: {
+        options: {
+          offset,
+          ...modifiers.offset?.options,
+        },
+      },
+      arrow: {
+        ...modifiers.arrow,
+        enabled: !!arrowElement,
+        options: {
+          ...modifiers.arrow?.options,
+          element: arrowElement,
+        },
+      },
+      flip: {
+        enabled: !!flip,
+        ...modifiers.flip,
+      },
+    }),
+  };
+}

--- a/src/usePopper.ts
+++ b/src/usePopper.ts
@@ -23,15 +23,17 @@ export type Placement = Popper.Placement;
 export type VirtualElement = Popper.VirtualElement;
 export type State = Popper.State;
 
-export type OffsetsFunction = (details: {
+export type OffsetValue = [
+  number | null | undefined,
+  number | null | undefined,
+];
+export type OffsetFunction = (details: {
   popper: Popper.Rect;
   reference: Popper.Rect;
   placement: Placement;
-}) => [number | null | undefined, number | null | undefined];
+}) => OffsetValue;
 
-export type Offset =
-  | OffsetsFunction
-  | [number | null | undefined, number | null | undefined];
+export type Offset = OffsetFunction | OffsetValue;
 
 export type ModifierMap = Record<string, Partial<Modifier<any, any>>>;
 export type Modifiers =

--- a/test/usePopperSpec.js
+++ b/test/usePopperSpec.js
@@ -31,7 +31,7 @@ describe('usePopper', () => {
     elements.mount.parentNode.removeChild(elements.mount);
   });
 
-  it('allows enabledEvents shortcut', (done) => {
+  it('should return state', (done) => {
     const result = renderHook(() =>
       usePopper(elements.reference, elements.popper, {
         eventsEnabled: true,
@@ -39,27 +39,10 @@ describe('usePopper', () => {
     );
 
     setTimeout(() => {
-      expect(result.current.state.modifiersData.eventListeners).to.be.ok;
-      done();
-    });
-  });
-
-  it('accepts a modifiers object', (done) => {
-    const spy = sinon.spy();
-    renderHook(() =>
-      usePopper(elements.reference, elements.popper, {
-        modifiers: {
-          test: {
-            enabled: true,
-            phase: 'write',
-            fn: spy,
-          },
-        },
-      }),
-    );
-
-    setTimeout(() => {
-      expect(spy).to.have.been.calledOnce;
+      expect(result.current.update).to.be.a('function');
+      expect(result.current.forceUpdate).to.be.a('function');
+      expect(result.current.styles).to.have.any.key('popper');
+      expect(result.current.attributes).to.have.any.key('popper');
       done();
     });
   });

--- a/www/src/examples/Dropdown.mdx
+++ b/www/src/examples/Dropdown.mdx
@@ -28,6 +28,7 @@ const MenuContainer = styled("div")`
 const Menu = ({ role }) => {
   const { show, onClose, props } = useDropdownMenu({
     flip: true,
+    offset: [0, 8],
   });
   return (
     <MenuContainer {...props} role={role} show={show}>

--- a/www/src/examples/Overlay.mdx
+++ b/www/src/examples/Overlay.mdx
@@ -3,77 +3,34 @@ A powerful and flexible overlay component for showing things over, and next to, 
 ```jsx
 import { Overlay } from "react-overlays";
 
-// Styles mostly from Bootstrap.
-
 const Tooltip = styled("div")`
   position: absolute;
-  padding: 0 5px;
-
-  ${(p) => {
-    switch (p.placement) {
-      case "left":
-        return css`
-          padding: 0 5px;
-        `;
-      case "right":
-        return css`
-          padding: 0 5px;
-        `;
-      case "top":
-        return css`
-          padding: 5px 0;
-        `;
-      case "bottom":
-        return css`
-          padding: 5px 0;
-        `;
-      default:
-        return "";
-    }
-  }}
 `;
 
 const Arrow = styled("div")`
   position: absolute;
-  width: 0;
-  height: 0;
-  border-style: solid;
-  opacity: 0.75;
+  width: 10px;
+  height: 10px;
+  z-index: -1;
 
-  ${(p) => {
-    switch (p.placement) {
-      case "left":
-        return css`
-          right: 0;
-          border-width: 5px 0 5px 5px;
-          border-color: transparent transparent transparent
-            #000;
-        `;
-      case "right":
-        return css`
-          left: 0;
-          border-width: 5px 5px 5px 0;
-          border-color: transparent #232323 transparent
-            transparent;
-        `;
-      case "top":
-        return css`
-          bottom: 0;
-          border-width: 5px 5px 0;
-          border-color: #232323 transparent transparent
-            transparent;
-        `;
-      case "bottom":
-        return css`
-          top: 0;
-          border-width: 0 5px 5px;
-          border-color: transparent transparent #232323
-            transparent;
-        `;
-      default:
-        return "";
-    }
-  }}
+  &::before {
+    content: "";
+    position: absolute;
+    transform: rotate(45deg);
+    background: #000;
+    width: 10px;
+    height: 10px;
+    top: 0;
+    left: 0;
+  }
+
+  ${(p) =>
+    ({
+      left: "right: -4px;",
+      right: "left: -4px;",
+      top: "bottom: -4px;",
+      bottom: "top: -4px;",
+    }[p.placement])}
 `;
 
 const Body = styled("div")`
@@ -82,7 +39,6 @@ const Body = styled("div")`
   text-align: center;
   border-radius: 3px;
   background-color: #000;
-  opacity: 0.75;
 `;
 
 const PLACEMENTS = ["left", "top", "right", "bottom"];
@@ -137,6 +93,7 @@ function OverlayExample() {
       <Overlay
         show={show}
         rootClose
+        offset={[0, 10]}
         onHide={() => dispatch("hide")}
         placement={placement}
         container={containerRef}


### PR DESCRIPTION
Should be fine to adapt in RB without a breaking change there

BREAKING CHANGE: popperConfig longer accept object forms of modifiers, pass an array instead
BREAKING CHANGE: overlay and dropdown menu injected values are different
BREAKING CHANGE: overlay no longer triggers an update when placement change due to auto or flip placements