### PR TITLE
[BS3] Modal accessibility fixes

### DIFF
--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -75,7 +75,7 @@ class ModalManager {
     this.modals.push(modal);
 
     if (this.hideSiblingNodes) {
-      hideSiblings(container, modal.mountNode);
+      hideSiblings(container, modal.modalNode);
     }
 
     if (containerIdx !== -1) {
@@ -131,7 +131,7 @@ class ModalManager {
       }
 
       if (this.hideSiblingNodes) {
-        showSiblings(container, modal.mountNode);
+        showSiblings(container, modal.modalNode);
       }
       this.containers.splice(containerIdx, 1);
       this.data.splice(containerIdx, 1);

--- a/src/ModalManager.js
+++ b/src/ModalManager.js
@@ -138,7 +138,7 @@ class ModalManager {
     }
     else if (this.hideSiblingNodes) {
       //otherwise make sure the next top modal is visible to a SR
-      ariaHidden(false, data.modals[data.modals.length - 1].mountNode);
+      ariaHidden(false, data.modals[data.modals.length - 1].modalNode);
     }
   }
 

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -110,6 +110,17 @@ describe('ModalManager', ()=> {
       expect(app.getAttribute('aria-hidden')).to.equal('true');
     });
 
+    it('should not add aria-hidden to modal', ()=>{
+      let modal = new Modal({});
+      let mount = document.createElement('div');
+
+      modal.modalNode = mount;
+      container.appendChild(mount);
+      manager.add(modal, container);
+
+      expect(mount.getAttribute('aria-hidden')).to.equal(null);
+    });
+
     it('should add aria-hidden to previous modals', ()=>{
       let modalA = new Modal({});
       let mount = document.createElement('div');

--- a/test/ModalManagerSpec.js
+++ b/test/ModalManagerSpec.js
@@ -140,7 +140,7 @@ describe('ModalManager', ()=> {
       let modalB = new Modal({});
       let mount = document.createElement('div');
 
-      modalA.mountNode = mount;
+      modalA.modalNode = mount;
       container.appendChild(mount);
 
       manager.add(modalA, container);


### PR DESCRIPTION
Fixes a couple modal accessibility issues in the 0.9 branch for react-bootstrap 0.33:

* https://github.com/react-bootstrap/react-bootstrap/issues/4790: active modals have `aria-hidden="true"` (regression introduced when react-bootstrap 0.33 upgraded to react-overlays 0.9)
* https://github.com/react-bootstrap/react-overlays/issues/240: closing a modal when multiple modals are open doesn't remove `aria-hidden="true"` from the next top modal (old issue, but still present in react-bootstrap 0.33)