### PR TITLE
feat(Overlay): Allow popper virtual elements as targets

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -9,6 +9,7 @@ import usePopper, {
   UsePopperOptions,
   Offset,
   State,
+  VirtualElement,
 } from './usePopper';
 import useRootClose, { RootCloseOptions } from './useRootClose';
 import useWaitForDOMRef, { DOMContainer } from './useWaitForDOMRef';
@@ -22,7 +23,7 @@ export interface OverlayProps extends TransitionCallbacks {
   containerPadding?: number;
   popperConfig?: Omit<UsePopperOptions, 'placement'>;
   container?: DOMContainer;
-  target: DOMContainer;
+  target: DOMContainer<HTMLElement | VirtualElement>;
   show?: boolean;
   transition?: React.ComponentType<
     { in?: boolean; appear?: boolean } & TransitionCallbacks
@@ -69,7 +70,7 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     const mergedRef = useMergedRefs<HTMLElement | null>(attachRef, outerRef);
 
     const container = useWaitForDOMRef(props.container);
-    const target = useWaitForDOMRef(props.target);
+    const target = useWaitForDOMRef<HTMLElement | VirtualElement>(props.target);
 
     const [exited, setExited] = useState(!props.show);
 
@@ -164,8 +165,8 @@ Overlay.propTypes = {
   placement: PropTypes.oneOf(placements),
 
   /**
-   * A DOM Element, Ref to an element, or function that returns either. The `target` element is where
-   * the overlay is positioned relative to.
+   * A DOM Element, [Virtual Element](https://popper.js.org/docs/v2/virtual-elements/), Ref to an element, or
+   * function that returns either. The `target` element is where the overlay is positioned relative to.
    */
   target: PropTypes.any,
 

--- a/src/useWaitForDOMRef.ts
+++ b/src/useWaitForDOMRef.ts
@@ -1,13 +1,12 @@
 import ownerDocument from 'dom-helpers/ownerDocument';
 import { useState, useEffect } from 'react';
+import { VirtualElement } from './usePopper';
 
-export type DOMContainer<T extends HTMLElement = HTMLElement> =
-  | T
-  | React.RefObject<T>
-  | null
-  | (() => T | React.RefObject<T> | null);
+export type DOMContainer<
+  T extends HTMLElement | VirtualElement = HTMLElement
+> = T | React.RefObject<T> | null | (() => T | React.RefObject<T> | null);
 
-export const resolveContainerRef = <T extends HTMLElement>(
+export const resolveContainerRef = <T extends HTMLElement | VirtualElement>(
   ref: DOMContainer<T> | undefined,
 ): T | HTMLBodyElement | null => {
   if (typeof document === 'undefined') return null;
@@ -15,12 +14,14 @@ export const resolveContainerRef = <T extends HTMLElement>(
   if (typeof ref === 'function') ref = ref();
 
   if (ref && 'current' in ref) ref = ref.current;
-  if (ref?.nodeType) return ref || null;
+  if (ref && ('nodeType' in ref || ref.getBoundingClientRect)) return ref;
 
   return null;
 };
 
-export default function useWaitForDOMRef<T extends HTMLElement = HTMLElement>(
+export default function useWaitForDOMRef<
+  T extends HTMLElement | VirtualElement = HTMLElement
+>(
   ref: DOMContainer<T> | undefined,
   onResolved?: (element: T | HTMLBodyElement) => void,
 ) {

--- a/test/WaitForContainerSpec.js
+++ b/test/WaitForContainerSpec.js
@@ -28,10 +28,59 @@ describe('useWaitForDOMRef', () => {
     onResolved.should.have.been.calledOnce;
   });
 
-  it('should resolve on first render if possible (ref)', () => {
+  it('should resolve on first render if possible (Virtual Element)', () => {
+    let renderCount = 0;
+    const container = {
+      getBoundingClientRect: () => new DOMRect(),
+    };
+
+    function Test({ container, onResolved }) {
+      useWaitForDOMRef(container, onResolved);
+      renderCount++;
+      return null;
+    }
+
+    const onResolved = sinon.spy((resolved) => {
+      expect(resolved).to.equal(container);
+    });
+
+    act(() => {
+      mount(<Test container={container} onResolved={onResolved} />);
+    });
+
+    renderCount.should.equal(1);
+    onResolved.should.have.been.calledOnce;
+  });
+
+  it('should resolve on first render if possible (element ref)', () => {
     let renderCount = 0;
     const container = React.createRef();
     container.current = document.createElement('div');
+
+    function Test({ container, onResolved }) {
+      useWaitForDOMRef(container, onResolved);
+      renderCount++;
+      return null;
+    }
+
+    const onResolved = sinon.spy((resolved) => {
+      expect(resolved).to.equal(container.current);
+    });
+
+    act(() => {
+      mount(<Test container={container} onResolved={onResolved} />);
+    });
+
+    renderCount.should.equal(1);
+    onResolved.should.have.been.calledOnce;
+  });
+
+  it('should resolve on first render if possible (Virtual Element ref)', () => {
+    let renderCount = 0;
+    const container = React.createRef();
+    container.current = {
+      getBoundingClientRect: () => new DOMRect(),
+    };
 
     function Test({ container, onResolved }) {
       useWaitForDOMRef(container, onResolved);


### PR DESCRIPTION
This changes `useWaitForDOMRef` to not filter out popper's virtual elements. I figured there was sufficient overlap in the element interfaces to put it in this function.