### PR TITLE
chore(ci): Fix brew cask install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         run: brew update
       - name: Install Chrome (macOS)
         if: matrix.os == 'macOS-latest' && matrix.browser == 'ChromeHeadless'
-        run: brew cask install google-chrome
+        run: brew install --cask google-chrome
       - name: Install Firefox (macOS)
         if: matrix.os == 'macOS-latest' && matrix.browser == 'FirefoxHeadless'
-        run: brew cask install firefox
+        run: brew install --cask firefox
       - name: Install Dependencies
         run: yarn bootstrap
       - name: Run Tests


### PR DESCRIPTION
Fixes the following error

> Error: Calling brew cask install is disabled! Use brew install [--cask] instead.