### PR TITLE
Keyboard focus error dropdown

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -278,7 +278,10 @@ function Dropdown({
           (e) => {
             if (
               (e.key === 'Tab' && !e.target) ||
-              !menuRef.current!.contains(e.target as HTMLElement)
+              !(
+                menuRef.current &&
+                menuRef.current.contains(e.target as HTMLElement)
+              )
             ) {
               onToggle(false, event);
             }

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -47,10 +47,6 @@ export interface RenderModalBackdropProps {
   onClick: (event: React.SyntheticEvent) => void;
 }
 
-interface IndexSignature {
-  [other: string]: any;
-}
-
 /*
   Modal props are split into a version with and without index signature so that you can fully use them in another projects
   This is due to Typescript not playing well with index singatures e.g. when using Omit
@@ -85,7 +81,9 @@ export interface ModalPropsWithoutIndexSignaure extends TransitionCallbacks {
   };
 }
 
-export type ModalProps = ModalPropsWithoutIndexSignaure & IndexSignature;
+export interface ModalProps extends ModalPropsWithoutIndexSignaure {
+  [other: string]: any;
+}
 
 function getManager() {
   if (!manager) manager = new ModalManager();

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -51,7 +51,7 @@ export interface RenderModalBackdropProps {
   Modal props are split into a version with and without index signature so that you can fully use them in another projects
   This is due to Typescript not playing well with index singatures e.g. when using Omit
 */
-export interface ModalPropsWithoutIndexSignaure extends TransitionCallbacks {
+export interface BaseModalProps extends TransitionCallbacks {
   children?: React.ReactElement;
   role?: string;
   style?: React.CSSProperties;
@@ -81,7 +81,7 @@ export interface ModalPropsWithoutIndexSignaure extends TransitionCallbacks {
   };
 }
 
-export interface ModalProps extends ModalPropsWithoutIndexSignaure {
+export interface ModalProps extends BaseModalProps {
   [other: string]: any;
 }
 

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -46,7 +46,16 @@ export interface RenderModalBackdropProps {
   ref: React.RefCallback<Element>;
   onClick: (event: React.SyntheticEvent) => void;
 }
-export interface ModalProps extends TransitionCallbacks {
+
+interface IndexSignature {
+  [other: string]: any;
+}
+
+/*
+  Modal props are split into a version with and without index signature so that you can fully use them in another projects
+  This is due to Typescript not playing well with index singatures e.g. when using Omit
+*/
+export interface ModalPropsWithoutIndexSignaure extends TransitionCallbacks {
   children?: React.ReactElement;
   role?: string;
   style?: React.CSSProperties;
@@ -74,9 +83,9 @@ export interface ModalProps extends TransitionCallbacks {
   restoreFocusOptions?: {
     preventScroll: boolean;
   };
-
-  [other: string]: any;
 }
+
+export type ModalProps = ModalPropsWithoutIndexSignaure & IndexSignature;
 
 function getManager() {
   if (!manager) manager = new ModalManager();


### PR DESCRIPTION
Resolves: https://github.com/react-bootstrap/react-bootstrap/issues/5883

Tested using next.js in development mode. (Fun fact: i've been able to reproduce this bug only using next js and only in dev mode - in production everything worked fine)