### PR TITLE
fix(Dropdown): avoid calling onToggle when tabbing if menu ref not set

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -248,6 +248,10 @@ function Dropdown({
       return;
     }
 
+    if (!menuRef.current && key === 'Tab') {
+      return;
+    }
+
     lastSourceEvent.current = event.type;
 
     switch (key) {

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -335,6 +335,26 @@ describe('<Dropdown>', () => {
     });
   });
 
+  it('should not call onToggle if the menu is not open and "tab" is pressed', () => {
+    const onToggleSpy = sinon.spy();
+    const wrapper = mount(<SimpleDropdown onToggle={onToggleSpy} />, {
+      attachTo: focusableContainer,
+    });
+
+    const toggle = wrapper.find('.toggle').getDOMNode();
+    toggle.focus();
+
+    simulant.fire(toggle, 'keydown', {
+      key: 'Tab',
+    });
+
+    simulant.fire(document, 'keyup', {
+      key: 'Tab',
+    });
+
+    onToggleSpy.should.not.be.called;
+  });
+
   describe('popper config', () => {
     it('can add modifiers', (done) => {
       const spy = sinon.spy();


### PR DESCRIPTION
Avoids calling `onToggle(false)` when "tab" is pressed and the dropdown is closed